### PR TITLE
configs: fix pmoved_msec -> pmove_msec

### DIFF
--- a/configs/legacy3.config
+++ b/configs/legacy3.config
@@ -160,7 +160,7 @@ init
 	command "sv_cvar m_yaw IN -0.022 0.022"
 
 	command "sv_cvar pmove_fixed EQ 0"
-	command "sv_cvar pmoved_msec EQ 8"
+	command "sv_cvar pmove_msec EQ 8"
 
 	command "sv_cvar r_ambientScale EQ 1.5"
 	command "sv_cvar r_drawentities EQ 1"

--- a/configs/legacy3_svfps50.config
+++ b/configs/legacy3_svfps50.config
@@ -161,7 +161,7 @@ init
 	command "sv_cvar m_yaw IN -0.022 0.022"
 
 	command "sv_cvar pmove_fixed EQ 0"
-	command "sv_cvar pmoved_msec EQ 8"
+	command "sv_cvar pmove_msec EQ 8"
 
 	command "sv_cvar r_ambientScale EQ 1.5"
 	command "sv_cvar r_drawentities EQ 1"

--- a/configs/legacy6.config
+++ b/configs/legacy6.config
@@ -160,7 +160,7 @@ init
 	command "sv_cvar m_yaw IN -0.022 0.022"
 
 	command "sv_cvar pmove_fixed EQ 0"
-	command "sv_cvar pmoved_msec EQ 8"
+	command "sv_cvar pmove_msec EQ 8"
 
 	command "sv_cvar r_ambientScale EQ 1.5"
 	command "sv_cvar r_drawentities EQ 1"

--- a/configs/legacy6OSDC.config
+++ b/configs/legacy6OSDC.config
@@ -159,7 +159,7 @@ init
 	command "sv_cvar m_yaw IN -0.022 0.022"
 
 	command "sv_cvar pmove_fixed EQ 0"
-	command "sv_cvar pmoved_msec EQ 8"
+	command "sv_cvar pmove_msec EQ 8"
 
 	command "sv_cvar r_ambientScale EQ 1.5"
 	command "sv_cvar r_drawentities EQ 1"

--- a/configs/legacy6_svfps50.config
+++ b/configs/legacy6_svfps50.config
@@ -161,7 +161,7 @@ init
 	command "sv_cvar m_yaw IN -0.022 0.022"
 
 	command "sv_cvar pmove_fixed EQ 0"
-	command "sv_cvar pmoved_msec EQ 8"
+	command "sv_cvar pmove_msec EQ 8"
 
 	command "sv_cvar r_ambientScale EQ 1.5"
 	command "sv_cvar r_drawentities EQ 1"


### PR DESCRIPTION
Correct sv_cvar name in legacy3, legacy6, and legacy6OSDC configs (including svfps50 variants where applicable).