### PR TITLE
Adds score tracking  to ng (non-gather) games. 

### DIFF
--- a/luascripts/README.md
+++ b/luascripts/README.md
@@ -128,6 +128,8 @@ gather feature flags, and (when `AUTO_SCORES` is on) the current score state.
 |-------|------|-------------|
 | `alpha` | number | Alpha team cumulative score |
 | `beta` | number | Beta team cumulative score |
+| `alpha_teamname` | string \| null | Alpha team display name (gather: from route; ng: tag-detected) |
+| `beta_teamname` | string \| null | Beta team display name |
 | `completed_maps` | number | Maps fully played (both rounds done) |
 | `match_finished` | boolean | True if match is over |
 | `match_winner` | `"alpha"` \| `"beta"` \| `"draw"` \| null | Winner, or null if still in progress |
@@ -610,6 +612,8 @@ interface MatchInfoScoresRound {
 interface MatchInfoScores {
   alpha:          number;
   beta:           number;
+  alpha_teamname: string | null;
+  beta_teamname:  string | null;
   completed_maps: number;
   match_finished: boolean;
   match_winner:   "alpha" | "beta" | "draw" | null;
@@ -839,19 +843,19 @@ while still in GS_WARMUP, a 5-second late-join countdown triggers automatically.
 Tracks match scores using ET stopwatch rules. Operates in two modes depending on whether a
 gather match is active:
 
-**Gather mode** — activated when `AUTO_SCORES=true` and the match-manager API returns
-`auto_scores=true` in match data. Enforces BO3 termination (match ends at 3 pts or after
-map 3). Score state persists across round resets (wiped only on a new `match_id`).
+**Gather mode** — activated when `AUTO_SCORES=true` and the match-manager route carries
+`is_gather=true`. Enforces BO3 termination (match ends at 3 pts or after map 3). Score state
+persists across round resets (wiped only on a new `match_id`).
 
-**ng (non-gather) mode** — activated when `AUTO_SCORES=true` and no gather match is active
-(scrims, tournaments, public matches). Scores accumulate indefinitely with no BO3 termination.
-Match identity is maintained across `et_InitGame` restarts via GUID continuity: if ≥65% of
-the in-team GUIDs from round 1 are still present at round 2 start, the match continues;
-otherwise a new match is started. State is persisted to `{match_id}_team_data.json` between
-restarts.
+**ng (non-gather) mode** — activated when `AUTO_SCORES=true` and the route does not carry
+`is_gather=true` (scrims, tournaments, public matches). Scores accumulate indefinitely with no
+BO3 termination. Match identity is maintained across `et_InitGame` restarts via GUID
+continuity: if ≥65% of the in-team GUIDs from round 1 are still present at round 2 start, the
+match continues; otherwise a new match is started. State is persisted to
+`{match_id}_team_data.json` between restarts.
 
-Both modes embed the current score state into every stats submission under `metadata.scores`
-and announce the score in chat during intermission.
+Both modes embed the current score state into every stats submission under `metadata.scores` and announce the score in chat during intermission.
+
 
 Scoring rules (both modes):
 

--- a/luascripts/README.md
+++ b/luascripts/README.md
@@ -687,8 +687,7 @@ The match-ID endpoint is called as `GET {API_URL_MATCHID}/{server_ip}/{server_po
 ### [GATHER FEATURES]
 
 Gather features only activate when the match-manager API returns a route for this server with
-the corresponding flag set (`auto_rename`, `auto_sort`, `auto_start`). They have no effect on
-non-gather matches.
+the corresponding flag set (`auto_rename`, `auto_sort`, `auto_start`). They have no effect on ng (non-gather) matches.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -697,7 +696,7 @@ non-gather matches.
 | `AUTO_START` | `false` | Countdown to `scheduled_start` from match data and force-start via `ref allready`. Includes a late-join 5-second countdown if all players arrive after the scheduled time. |
 | `AUTO_MAP` | `false` | Automatically switch to the next map in the match rotation after round 2 intermission ends. |
 | `AUTO_CONFIG` | `false` | Apply server config via `ref config <name>` based on roster player count at map 1 round 1 warmup. |
-| `AUTO_SCORES` | `false` | **[EXPERIMENTAL]** Track match scores across a best-of-3 map series using ET stopwatch rules. Embeds current score state into the stats submission as `metadata.scores`. Announces current score in chat during intermission. Requires `auto_scores=true` in match data. |
+| `AUTO_SCORES` | `false` | Track match scores using ET stopwatch rules. Active for **gather matches** (requires `auto_scores=true` in match data, BO3 termination enforced) and **ng matches** (always-on when no gather match is active, scores accumulate indefinitely). Embeds current score state into stats submissions as `metadata.scores`. Announces score in chat during intermission. |
 | `VERSION_CHECK` | `true` | Check `API_URL_VERSION` at startup and broadcast a chat warning if outdated |
 
 ### [AUTO-CONFIG MAP]
@@ -803,7 +802,7 @@ Each map is declared under `[maps.<mapname>]`. Supported sub-sections:
 ## Gather features
 
 All gather features require the match-manager API to return a route for this server with
-the corresponding flag set. They have no effect on non-gather matches.
+the corresponding flag set. They have no effect on ng (non-gather) matches.
 
 ### AUTO_RENAME
 
@@ -837,25 +836,38 @@ while still in GS_WARMUP, a 5-second late-join countdown triggers automatically.
 
 ### AUTO_SCORES
 
-Tracks match scores across a best-of-3 map series using ET stopwatch rules. Score state
-persists across round resets (only wiped when a new `match_id` is detected) and is embedded
-into every stats submission under `match_info.scores`.
+Tracks match scores using ET stopwatch rules. Operates in two modes depending on whether a
+gather match is active:
 
-Scoring rules:
+**Gather mode** — activated when `AUTO_SCORES=true` and the match-manager API returns
+`auto_scores=true` in match data. Enforces BO3 termination (match ends at 3 pts or after
+map 3). Score state persists across round resets (wiped only on a new `match_id`).
+
+**ng (non-gather) mode** — activated when `AUTO_SCORES=true` and no gather match is active
+(scrims, tournaments, public matches). Scores accumulate indefinitely with no BO3 termination.
+Match identity is maintained across `et_InitGame` restarts via GUID continuity: if ≥65% of
+the in-team GUIDs from round 1 are still present at round 2 start, the match continues;
+otherwise a new match is started. State is persisted to `{match_id}_team_data.json` between
+restarts.
+
+Both modes embed the current score state into every stats submission under `metadata.scores`
+and announce the score in chat during intermission.
+
+Scoring rules (both modes):
 
 - **Map win** (team wins both rounds): +2 pts to winner
 - **Map draw** (split 1-1): +1 pt each
 - **Fullhold** (`timelimit == nextTimeLimit`): defending team gets provisional +1 after r1
   - **Double fullhold** (both teams hold): provisional removed, +1 each
   - **Normal r2 after r1 fullhold**: provisional removed, normal result applied
-- **Clinch** (only possible at 2-0 + r1 fullhold provisional = 3-0): match ends before r2
+- **Clinch** (only possible at 2-0 + r1 fullhold provisional = 3-0): match ends before r2 *(gather only)*
 
-Team-side validation runs at every round end: connected player GUIDs are matched against the
-alpha roster from match data. If ≥80% of matched players are on the expected ET team, the
-assignment is confirmed; otherwise the detected side is used. Falls back to the static
-side table if detection is inconclusive.
+Team-side validation (gather mode): connected player GUIDs are matched against the alpha
+roster from match data. If ≥80% of matched players are on the expected ET team, the assignment
+is confirmed; otherwise the detected side is used. Falls back to the static side table if
+detection is inconclusive.
 
-Possible final scores: **3-0** (clinch), **4-0**, **3-1**, **4-2**, **3-3** (draw).
+Possible final scores (gather): **3-0** (clinch), **4-0**, **3-1**, **4-2**, **3-3** (draw).
 
 ---
 
@@ -878,7 +890,7 @@ luascripts/
     ├── util/
     │   ├── log.lua             timestamped file logger (info / debug levels)
     │   ├── http.lua            async/sync curl helpers
-    │   └── utils.lua           strip_colors, normalize, sanitize, distance, …
+    │   └── utils.lua           strip_colors, normalize, sanitize, distance, get_connected_players, …
     ├── config.lua              TOML loader
     ├── players.lua             GUID cache, get_snapshot(), class-switch detection
     ├── movement.lua            per-frame stance + distance + speed tracking
@@ -887,7 +899,8 @@ luascripts/
     ├── objectives.lua          et_Print pattern matching, buildables, flags, shoves
     ├── gather.lua              gather features: auto_rename, auto_sort, auto_start, auto_scores
     ├── api.lua                 match-ID fetch, version check
-    ├── scores.lua              match score tracking across a best-of-3 series (gather only)
+    ├── scores.lua              match score tracking (gather + ng modes)
+    ├── ng_scores.lua           ng match lifecycle: GUID continuity, persistence, roster
     ├── stats.lua               StoreStats, SaveStats, JSON assembly
     └── gamestate.lua           GS change detection, intermission countdown, reset
 ```

--- a/luascripts/stats.lua
+++ b/luascripts/stats.lua
@@ -368,13 +368,13 @@ function et_InitGame()
             local cached = {}
             gather.load_team_data_from_file(cached)
             if cached[1] then api.cached_match_id = cached[1] end
-            if AUTO_SCORES and not gather.is_scores_active() then
+            if AUTO_SCORES and not gather.is_gather() then
                 ng_scores.load_from_file()
                 _ng_round_start_pending = true
             end
         end
     elseif (current_gs == et.GS_WARMUP or current_gs == et.GS_WARMUP_COUNTDOWN)
-        and (AUTO_RENAME or AUTO_SORT or AUTO_START or AUTO_MAP or AUTO_CONFIG or AUTO_SCORES) then
+        and (AUTO_RENAME or AUTO_SORT or AUTO_START or AUTO_MAP or AUTO_CONFIG) then
         log_mod.write(string.format("Warmup (gs=%d) — fetching match data", current_gs))
         local mid = api.fetch_match_id()
         if mid then

--- a/luascripts/stats.lua
+++ b/luascripts/stats.lua
@@ -1,6 +1,6 @@
 --[[
     stats.lua  — root module for ETLegacy game stats collection
-    Version: 2.2.0
+    Version: 2.2.1
 
     All user-facing settings live in the CONFIGURATION block below.
     config.toml is kept only for map-specific patterns and common buildables.
@@ -41,7 +41,7 @@ local AUTO_START                = false  -- foce game start via AUTO_START_WAIT 
 local AUTO_RENAME               = false  -- enforce team names via API
 local AUTO_MAP                  = false  -- switch to next map in rotation after round 2 intermission
 local AUTO_CONFIG               = false  -- apply server config (ref config) based on player count at match start
-local AUTO_SCORES               = false  -- track match scores across maps (best-of-3)
+local AUTO_SCORES               = true   -- track match scores across maps
 local VERSION_CHECK             = true
 
 -- [AUTO-CONFIG MAP] player count → server config name
@@ -63,7 +63,7 @@ local SAVE_STATS_DELAY          = 3000   -- ms after intermission before SaveSta
 
 -- [MODULE]
 local MODNAME                   = "stats"
-local VERSION                   = "2.2.0"
+local VERSION                   = "2.2.1"
 
 -- [ENV OVERRIDES]
 -- Any setting above can be overridden by an environment variable of the same
@@ -135,6 +135,7 @@ local gather                    = gs_require("gather")
 local api                       = gs_require("api")
 local stats                     = gs_require("stats")
 local scores                    = gs_require("scores")
+local ng_scores                 = gs_require("ng_scores")
 local gamestate                 = gs_require("gamestate")
 
 -- [RUNTIME VARIABLES]
@@ -147,6 +148,7 @@ local common_buildables         = {}
 local next_store_time           = 0
 local level_time                = 0
 local _deferred_init_pending    = false
+local _ng_round_start_pending   = false
 
 -- [SHARED CONFIG TABLE] (passed to modules at init)
 local function build_cfg()
@@ -308,6 +310,7 @@ function et_InitGame()
     events.init(cfg, log_mod, players, gamelog, objectives)
     objectives.init(cfg, log_mod, players, gamelog)
     scores.init(cfg, log_mod, http, gamestate)
+    ng_scores.init(cfg, log_mod, scores, http)
     gather.init(cfg, log_mod, http, api, scores)
     api.init(cfg, log_mod, http, gather, VERSION)
     api.set_server_info(server_ip, server_port)
@@ -323,6 +326,7 @@ function et_InitGame()
         api        = api,
         stats      = stats,
         scores     = scores,
+        ng_scores  = ng_scores,
     })
 
     events.parse_reinf_times()
@@ -364,6 +368,10 @@ function et_InitGame()
             local cached = {}
             gather.load_team_data_from_file(cached)
             if cached[1] then api.cached_match_id = cached[1] end
+            if AUTO_SCORES and not gather.is_scores_active() then
+                ng_scores.load_from_file()
+                _ng_round_start_pending = true
+            end
         end
     elseif (current_gs == et.GS_WARMUP or current_gs == et.GS_WARMUP_COUNTDOWN)
         and (AUTO_RENAME or AUTO_SORT or AUTO_START or AUTO_MAP or AUTO_CONFIG or AUTO_SCORES) then
@@ -404,6 +412,14 @@ function et_RunFrame(frame_level_time)
     if _deferred_init_pending then
         _deferred_init_pending = false
         api.check_version()
+    end
+
+    if _ng_round_start_pending then
+        local team_players = utils.get_connected_players()
+        if #team_players > 0 then
+            _ng_round_start_pending = false
+            ng_scores.on_round_start()
+        end
     end
 
     events.set_level_time(level_time)

--- a/luascripts/stats/gamestate.lua
+++ b/luascripts/stats/gamestate.lua
@@ -18,6 +18,7 @@ local gather_ref
 local api_ref
 local stats_ref
 local scores_ref
+local ng_scores_ref
 
 gamestate.current          = -1
 gamestate._last_gs_raw     = ""
@@ -44,6 +45,7 @@ function gamestate.init(cfg, log_ref, all_modules)
     api_ref        = all_modules.api
     stats_ref      = all_modules.stats
     scores_ref     = all_modules.scores
+    ng_scores_ref  = all_modules.ng_scores
 
     _save_stats_delay = cfg.save_stats_delay or 3000
 end
@@ -59,6 +61,7 @@ function gamestate.reset(server_ip, server_port)
     if stats_ref      then stats_ref.reset()             end
     if gather_ref     then gather_ref.reset()            end
     if scores_ref     then scores_ref.reset()            end
+    if ng_scores_ref  then ng_scores_ref.reset()         end
     if gather_ref     then gather_ref.reset_team_data()  end
     -- team data is cleared here, after stats.save() and the post-save team_data.json
 
@@ -82,6 +85,10 @@ function gamestate.handle_change(new_gs, server_ip, server_port, frame_time)
             -- During playing, only load team data from file (no API calls)
             local cached = { nil }
             gather_ref.load_team_data_from_file(cached)
+        end
+
+        if ng_scores_ref and not (gather_ref and gather_ref.is_scores_active()) then
+            ng_scores_ref.on_round_start()
         end
 
         if gamelog_ref then gamelog_ref.round_start() end
@@ -137,6 +144,9 @@ function gamestate.tick(frame_time, server_ip, server_port)
             -- on_team_data_fetched) and survives the et_InitGame VM reset via restore_state().
             local save_match_id = scores_ref and scores_ref.get_match_id() or nil
             if gather_ref then gather_ref.save_team_data_to_file(save_match_id) end
+            if ng_scores_ref and ng_scores_ref.is_active() then
+                ng_scores_ref.save_to_file()
+            end
 
             gamestate.reset(server_ip, server_port)
         end

--- a/luascripts/stats/gamestate.lua
+++ b/luascripts/stats/gamestate.lua
@@ -87,7 +87,7 @@ function gamestate.handle_change(new_gs, server_ip, server_port, frame_time)
             gather_ref.load_team_data_from_file(cached)
         end
 
-        if ng_scores_ref and not (gather_ref and gather_ref.is_scores_active()) then
+        if ng_scores_ref and not (gather_ref and gather_ref.is_gather()) then
             ng_scores_ref.on_round_start()
         end
 
@@ -131,6 +131,10 @@ function gamestate.tick(frame_time, server_ip, server_port)
             and not gamestate.save_stats_state.in_progress then
 
             gamestate.save_stats_state.in_progress = true
+
+            if ng_scores_ref and ng_scores_ref.is_active() then
+                ng_scores_ref.resolve_match_id(api_ref)
+            end
 
             stats_ref.save(
                 gamestate.round_start_time,

--- a/luascripts/stats/gather.lua
+++ b/luascripts/stats/gather.lua
@@ -287,15 +287,6 @@ function gather.load_team_data_from_file(cached_match_id_ref)
 end
 
 
-function gather.wipe_team_data_file()
-    local path = get_team_data_file_path(_route_match_id)
-    if not path then return false end
-    local ok = pcall(os.remove, path)
-    if ok and log then log.write("Team data file wiped") end
-    return ok
-end
-
-
 -- Compute scheduled_start and sides_swapped from current map and round.
 -- sides_swapped = (map_index + round) % 2 == 1
 --   map_index 0, round 0 → alpha=Axis (default)

--- a/luascripts/stats/gather.lua
+++ b/luascripts/stats/gather.lua
@@ -194,6 +194,7 @@ end
 
 function gather.save_team_data_to_file(match_id)
     if not _team_data_cache then return false end
+    if not (_match_extra and _match_extra.is_gather) then return false end
     local effective_id = match_id or _route_match_id
     local path = get_team_data_file_path(effective_id)
     if not path then return false end
@@ -240,7 +241,9 @@ function gather.load_team_data_from_file(cached_match_id_ref)
     end)
 
     if ok and result then
-        if result.ng then return false end
+        if result.ng or (result.match_extra and result.match_extra.is_gather == false) then
+            return false
+        end
         if result.match_id then
             if cached_match_id_ref then cached_match_id_ref[1] = result.match_id end
             _route_match_id = result.match_id
@@ -253,10 +256,11 @@ function gather.load_team_data_from_file(cached_match_id_ref)
         if result.match_extra then
             _match_extra = result.match_extra
             -- Re-derive effective flags; gather.init() reset them all to false.
-            _eff_rename  = _auto_rename  and (_match_extra.auto_rename  or false)
-            _eff_sort    = _auto_sort    and (_match_extra.auto_sort    or false)
-            _eff_start   = _auto_start   and (_match_extra.auto_start   or false)
-            _eff_map     = _auto_map     and (_match_extra.auto_map     or false)
+            local is_gather = _match_extra.is_gather or false
+            _eff_rename  = _auto_rename  and is_gather and (_match_extra.auto_rename  or false)
+            _eff_sort    = _auto_sort    and is_gather and (_match_extra.auto_sort    or false)
+            _eff_start   = _auto_start   and is_gather and (_match_extra.auto_start   or false)
+            _eff_map     = _auto_map     and is_gather and (_match_extra.auto_map     or false)
             _eff_scores  = _auto_scores  and (_match_extra.auto_scores  or false)
         end
         -- Pass all effective feature flags to scores so it can include them in metadata
@@ -378,6 +382,7 @@ function gather.on_team_data_fetched(match_id, match_data)
         maps            = match_data.maps            or {},
         channel_id      = match_data.channel_id      or nil,
         server_config   = match_data.server_config   or nil,
+        is_gather       = match_data.is_gather       or false,
     }
 
     -- Static master enable AND match_data must both be true.
@@ -385,11 +390,12 @@ function gather.on_team_data_fetched(match_id, match_data)
     -- from ng routes that carry no team data.
     local _cfg_alpha = match_data.alpha_team and #match_data.alpha_team or 0
     local _cfg_beta  = match_data.beta_team  and #match_data.beta_team  or 0
-    _eff_rename  = _auto_rename  and _match_extra.auto_rename
-    _eff_sort    = _auto_sort    and _match_extra.auto_sort
-    _eff_start   = _auto_start   and _match_extra.auto_start
-    _eff_map     = _auto_map     and _match_extra.auto_map
-    _eff_config  = _auto_config  and (_cfg_alpha + _cfg_beta) > 0
+    local is_gather = _match_extra.is_gather or false
+    _eff_rename  = _auto_rename  and is_gather and _match_extra.auto_rename
+    _eff_sort    = _auto_sort    and is_gather and _match_extra.auto_sort
+    _eff_start   = _auto_start   and is_gather and _match_extra.auto_start
+    _eff_map     = _auto_map     and is_gather and _match_extra.auto_map
+    _eff_config  = _auto_config  and is_gather and (_cfg_alpha + _cfg_beta) > 0
     _eff_scores  = _auto_scores  and _match_extra.auto_scores
 
     -- Pass all effective feature flags to scores so it can include them in metadata
@@ -494,8 +500,8 @@ function gather.is_team_data_available()
 end
 
 
-function gather.is_scores_active()
-    return _eff_scores
+function gather.is_gather()
+    return _match_extra and _match_extra.is_gather or false
 end
 
 

--- a/luascripts/stats/gather.lua
+++ b/luascripts/stats/gather.lua
@@ -175,16 +175,8 @@ function gather.reset_team_data()
 end
 
 
-local function get_team_data_dir()
-    local fs_basepath = et.trap_Cvar_Get("fs_basepath")
-    local fs_game     = et.trap_Cvar_Get("fs_game")
-    if not fs_basepath or not fs_game then return nil end
-    return string.format("%s/%s/luascripts", fs_basepath, fs_game)
-end
-
-
 local function get_team_data_file_path(match_id)
-    local dir = get_team_data_dir()
+    local dir = utils.get_team_data_dir()
     if not dir then return nil end
     if match_id and match_id ~= "" then
         return string.format("%s/%s_team_data.json", dir, match_id)
@@ -248,6 +240,7 @@ function gather.load_team_data_from_file(cached_match_id_ref)
     end)
 
     if ok and result then
+        if result.ng then return false end
         if result.match_id then
             if cached_match_id_ref then cached_match_id_ref[1] = result.match_id end
             _route_match_id = result.match_id
@@ -398,7 +391,7 @@ function gather.on_team_data_fetched(match_id, match_data)
 
     -- Static master enable AND match_data must both be true.
     -- _eff_config requires roster players (alpha+beta > 0) to distinguish gather matches
-    -- from non-gather routes that carry no team data.
+    -- from ng routes that carry no team data.
     local _cfg_alpha = match_data.alpha_team and #match_data.alpha_team or 0
     local _cfg_beta  = match_data.beta_team  and #match_data.beta_team  or 0
     _eff_rename  = _auto_rename  and _match_extra.auto_rename
@@ -507,6 +500,11 @@ function gather.is_team_data_available()
         and _team_data_cache ~= nil
         and _team_names_cache.alpha_teamname ~= nil
         and _team_names_cache.beta_teamname  ~= nil
+end
+
+
+function gather.is_scores_active()
+    return _eff_scores
 end
 
 
@@ -859,31 +857,22 @@ scan_players = function(match_data)
     add_roster_team(match_data.alpha_team, TEAM_AXIS)
     add_roster_team(match_data.beta_team,  TEAM_ALLIES)
 
-    local maxClients = tonumber(et.trap_Cvar_Get("sv_maxclients")) or 24
-    for clientNum = 0, maxClients - 1 do
-        if et.gentity_get(clientNum, "pers.connected") == 2 then
-            local userinfo = et.trap_GetUserinfo(clientNum)
-            if userinfo and userinfo ~= "" then
-                local guid   = string.upper(et.Info_ValueForKey(userinfo, "cl_guid") or "")
-                local ingame = et.Info_ValueForKey(userinfo, "name") or ""
-                local team   = tonumber(et.gentity_get(clientNum, "sess.sessionTeam")) or 0
-                local entry  = guid ~= "" and roster[guid] or nil
-
-                if entry then
-                    entry.found = true
-                    table.insert(connected, {
-                        guid       = guid,
-                        discord_id = entry.discord_id,
-                        name       = entry.name,
-                    })
-                else
-                    table.insert(unknown, {
-                        guid        = guid,
-                        ingame_name = ingame,
-                        team        = team,
-                    })
-                end
-            end
+    for _, p in ipairs(utils.get_connected_players()) do
+        local entry  = p.guid ~= "" and roster[p.guid] or nil
+        local ingame = et.Info_ValueForKey(et.trap_GetUserinfo(p.clientNum) or "", "name") or ""
+        if entry then
+            entry.found = true
+            table.insert(connected, {
+                guid       = p.guid,
+                discord_id = entry.discord_id,
+                name       = entry.name,
+            })
+        else
+            table.insert(unknown, {
+                guid        = p.guid,
+                ingame_name = ingame,
+                team        = p.team,
+            })
         end
     end
 
@@ -915,13 +904,9 @@ end
 local function count_ingame_teams()
     local axis   = 0
     local allies = 0
-    local maxClients = tonumber(et.trap_Cvar_Get("sv_maxclients")) or 24
-    for clientNum = 0, maxClients - 1 do
-        if et.gentity_get(clientNum, "pers.connected") == 2 then
-            local team = tonumber(et.gentity_get(clientNum, "sess.sessionTeam")) or 0
-            if team == TEAM_AXIS   then axis   = axis   + 1 end
-            if team == TEAM_ALLIES then allies = allies + 1 end
-        end
+    for _, p in ipairs(utils.get_connected_players()) do
+        if p.team == TEAM_AXIS   then axis   = axis   + 1 end
+        if p.team == TEAM_ALLIES then allies = allies + 1 end
     end
     return axis, allies
 end

--- a/luascripts/stats/ng_scores.lua
+++ b/luascripts/stats/ng_scores.lua
@@ -46,7 +46,7 @@ function ng_scores.init(cfg, log_ref, scores_module, http_module)
     scores_ref   = scores_module
     http_ref     = http_module
     _auto_scores = cfg and cfg.auto_scores or false
-    _api_token   = (cfg and cfg.api_token)  or ""
+    _api_token   = (cfg and cfg.api_token) or ""
 
     -- Derive players endpoint from submit URL: .../etl/matches/stats/submit → .../etl/players/by-guid
     local submit_url = cfg and cfg.api_url_submit or ""
@@ -93,6 +93,14 @@ function ng_scores.on_round_start()
     if not _auto_scores then return end
 
     if _match_id ~= nil then
+        local last = scores_ref and scores_ref.get_last_round()
+        if last and last.round_num == 1 then
+            if scores_ref then scores_ref.activate_ng_mode(_match_id, _alpha_name, _beta_name) end
+            _is_active = true
+            if log then log.write(string.format("ng: R2 start — match continued — match_id=%s", _match_id)) end
+            return
+        end
+
         local same, ratio = check_continuity()
         if log then
             log.write(string.format("ng: continuity check — ratio=%.2f threshold=%.2f same=%s",
@@ -114,21 +122,38 @@ function ng_scores.on_round_start()
         end
     end
 
-    -- New match
+    -- New match: capture team GUIDs for continuity checks; tag/name resolution deferred to intermission.
+    local players = utils.get_connected_players()
+    local n_axis, n_allies = 0, 0
+    _alpha_guids = {}
+    _beta_guids  = {}
+    for _, p in ipairs(players) do
+        if p.team == TEAM_AXIS   then _alpha_guids[p.guid] = true; n_axis   = n_axis   + 1 end
+        if p.team == TEAM_ALLIES then _beta_guids[p.guid]  = true; n_allies = n_allies + 1 end
+    end
+
+    _is_active = true
+
+    if scores_ref then scores_ref.activate_ng_mode(nil, nil, nil) end
+
+    if log then
+        log.write(string.format("ng: new match started — axis=%d allies=%d", n_axis, n_allies))
+    end
+end
+
+
+function ng_scores.resolve_match_id(api_ref)
+    if not _is_active then return end
+    if _match_id then return end
+
     local players    = utils.get_connected_players()
     local alpha_list = {}
     local beta_list  = {}
     for _, p in ipairs(players) do
-        if p.team == TEAM_AXIS   then alpha_list[#alpha_list + 1] = p end
-        if p.team == TEAM_ALLIES then beta_list[#beta_list   + 1] = p end
+        if _alpha_guids[p.guid] then alpha_list[#alpha_list + 1] = p end
+        if _beta_guids[p.guid]  then beta_list[#beta_list   + 1] = p end
     end
 
-    _alpha_guids = {}
-    for _, p in ipairs(alpha_list) do _alpha_guids[p.guid] = true end
-    _beta_guids  = {}
-    for _, p in ipairs(beta_list)  do _beta_guids[p.guid]  = true end
-
-    -- Attempt to determine tag, multiple fallbacks: prefix/suffix detection -> fetch from api -> use playername
     local function build_and_detect(list)
         if #list == 0 then return nil, nil end
         local entries = {}
@@ -150,9 +175,9 @@ function ng_scores.on_round_start()
                     entries[#entries + 1] = {
                         raw       = raw,
                         guid      = p.guid,
-                        first     = #tokens >= 2 and tokens[1]                 or nil,
-                        last      = #tokens >= 2 and tokens[#tokens]           or nil,
-                        raw_first = #raw_tokens >= 2 and raw_tokens[1]         or nil,
+                        first     = #tokens >= 2 and tokens[1]                   or nil,
+                        last      = #tokens >= 2 and tokens[#tokens]             or nil,
+                        raw_first = #raw_tokens >= 2 and raw_tokens[1]           or nil,
                         raw_last  = #raw_tokens >= 2 and raw_tokens[#raw_tokens] or nil,
                     }
                 end
@@ -223,14 +248,17 @@ function ng_scores.on_round_start()
     warn_fallback("Axis",   alpha_source, _alpha_name, alpha_raw)
     warn_fallback("Allies", beta_source,  _beta_name,  beta_raw)
 
-    _match_id  = tostring(os.time())
-    _is_active = true
+    local id = (api_ref and api_ref.fetch_match_id()) or tostring(os.time())
+    _match_id = id
 
-    if scores_ref then scores_ref.activate_ng_mode(_match_id, _alpha_name, _beta_name) end
+    if scores_ref then
+        scores_ref.set_match_id(id)
+        scores_ref.activate_ng_mode(id, _alpha_name, _beta_name)
+    end
 
     if log then
-        log.write(string.format("ng: new match — match_id=%s axis=%d allies=%d alpha_name=%s beta_name=%s",
-            _match_id, #alpha_list, #beta_list,
+        log.write(string.format("ng: match_id resolved — %s alpha=%s beta=%s",
+            id,
             utils.strip_colors(_alpha_name or "nil"),
             utils.strip_colors(_beta_name  or "nil")))
     end

--- a/luascripts/stats/ng_scores.lua
+++ b/luascripts/stats/ng_scores.lua
@@ -1,0 +1,367 @@
+--[[
+    stats/ng_scores.lua
+    Non-gather (ng) match scoring: tracks scores across rounds for matches
+    without API-managed gather data (scrims, tournaments).
+
+    A ng match begins when AUTO_SCORES=true and no gather match is active.
+    Match identity is maintained via GUID continuity across et_InitGame restarts:
+    if >= CONTINUITY_THRESHOLD of stored GUIDs are still connected at round start,
+    the match continues; otherwise a new match is started.
+
+    State is persisted to {match_id}_team_data.json (marked ng=true) in the same
+    directory as gather team data, using a compatible schema.
+--]]
+
+local ng_scores = {}
+
+local json  = require("dkjson")
+local utils = require("luascripts/stats/util/utils")
+
+local log
+local scores_ref
+local http_ref
+
+local _auto_scores  = false
+local _api_token    = ""
+local _players_url  = nil
+
+local CONTINUITY_THRESHOLD = 0.65
+local TEAM_AXIS            = 1
+local TEAM_ALLIES          = 2
+
+local TAG_THRESHOLD = 0.8
+local TAG_MIN_LEN   = 2
+local TAG_MAX_LEN   = 15
+
+local _match_id    = nil
+local _alpha_guids = {}
+local _beta_guids  = {}
+local _alpha_name  = nil   -- player name from first axis player at match start
+local _beta_name   = nil   -- player name from first allies player at match start
+local _is_active   = false
+
+
+function ng_scores.init(cfg, log_ref, scores_module, http_module)
+    log          = log_ref
+    scores_ref   = scores_module
+    http_ref     = http_module
+    _auto_scores = cfg and cfg.auto_scores or false
+    _api_token   = (cfg and cfg.api_token)  or ""
+
+    -- Derive players endpoint from submit URL: .../etl/matches/stats/submit → .../etl/players/by-guid
+    local submit_url = cfg and cfg.api_url_submit or ""
+    local base = submit_url:match("^(https?://.+/etl)")
+    _players_url = base and (base .. "/players/by-guid") or nil
+end
+
+
+-- No-op: ng state must survive rounds (persisted across et_InitGame via file).
+function ng_scores.reset()
+end
+
+
+function ng_scores.reset_match()
+    _match_id    = nil
+    _alpha_guids = {}
+    _beta_guids  = {}
+    _alpha_name  = nil
+    _beta_name   = nil
+    _is_active   = false
+    if scores_ref then scores_ref.reset_match() end
+    if log then log.write("ng: match state reset") end
+end
+
+
+
+function ng_scores.is_active()
+    return _is_active
+end
+
+
+function ng_scores.get_match_id()
+    return _match_id
+end
+
+
+local function check_continuity()
+    local stored = {}
+    for g in pairs(_alpha_guids) do stored[g] = true end
+    for g in pairs(_beta_guids)  do stored[g] = true end
+
+    local players = utils.get_connected_players()
+    local _, ratio = utils.guid_overlap(stored, players)
+    return ratio >= CONTINUITY_THRESHOLD, ratio
+end
+
+
+function ng_scores.on_round_start()
+    if not _auto_scores then return end
+
+    if _match_id ~= nil then
+        local same, ratio = check_continuity()
+        if log then
+            log.write(string.format("ng: continuity check — ratio=%.2f threshold=%.2f same=%s",
+                ratio, CONTINUITY_THRESHOLD, tostring(same)))
+        end
+        if not same then
+            if log then
+                log.write(string.format(
+                    "ng: roster changed below threshold (%.0f%%) — starting new match",
+                    ratio * 100))
+            end
+            ng_scores.reset_match()
+        else
+            -- Same match confirmed
+            if scores_ref then scores_ref.activate_ng_mode(_match_id, _alpha_name, _beta_name) end
+            _is_active = true
+            if log then log.write(string.format("ng: match continued — match_id=%s", _match_id)) end
+            return
+        end
+    end
+
+    -- New match
+    local players    = utils.get_connected_players()
+    local alpha_list = {}
+    local beta_list  = {}
+    for _, p in ipairs(players) do
+        if p.team == TEAM_AXIS   then alpha_list[#alpha_list + 1] = p end
+        if p.team == TEAM_ALLIES then beta_list[#beta_list   + 1] = p end
+    end
+
+    _alpha_guids = {}
+    for _, p in ipairs(alpha_list) do _alpha_guids[p.guid] = true end
+    _beta_guids  = {}
+    for _, p in ipairs(beta_list)  do _beta_guids[p.guid]  = true end
+
+    -- Attempt to determine tag, multiple fallbacks: prefix/suffix detection -> fetch from api -> use playername
+    local function build_and_detect(list)
+        if #list == 0 then return nil, nil end
+        local entries = {}
+        for _, p in ipairs(list) do
+            local ui  = et.trap_GetUserinfo(p.clientNum)
+            local raw = (ui and et.Info_ValueForKey(ui, "name")) or
+                        et.gentity_get(p.clientNum, "pers.netname") or ""
+            if raw ~= "" then
+                local stripped = utils.strip_colors(raw):match("^%s*(.-)%s*$") or ""
+                if stripped ~= "" then
+                    local tokens = {}
+                    for tok in stripped:gmatch("[^%s%._%-%|%[%]%(%)]+") do
+                        tokens[#tokens + 1] = tok
+                    end
+                    local raw_tokens = {}
+                    for tok in raw:gmatch("[^%s%._%-%|%[%]%(%)]+") do
+                        raw_tokens[#raw_tokens + 1] = tok
+                    end
+                    entries[#entries + 1] = {
+                        raw       = raw,
+                        guid      = p.guid,
+                        first     = #tokens >= 2 and tokens[1]                 or nil,
+                        last      = #tokens >= 2 and tokens[#tokens]           or nil,
+                        raw_first = #raw_tokens >= 2 and raw_tokens[1]         or nil,
+                        raw_last  = #raw_tokens >= 2 and raw_tokens[#raw_tokens] or nil,
+                    }
+                end
+            end
+        end
+        if #entries == 0 then return nil, nil end
+
+        local threshold = math.ceil(#entries * TAG_THRESHOLD)
+        local function best_tag(get_tok, get_raw_tok)
+            local freq = {}
+            for _, e in ipairs(entries) do
+                local t = get_tok(e)
+                if t then
+                    local lc = t:lower()
+                    if #lc >= TAG_MIN_LEN and #lc <= TAG_MAX_LEN then
+                        if not freq[lc] then
+                            freq[lc] = { raw = get_raw_tok(e) or t, count = 0 }
+                        end
+                        freq[lc].count = freq[lc].count + 1
+                    end
+                end
+            end
+            for _, v in pairs(freq) do
+                if v.count >= threshold then return v.raw end
+            end
+        end
+        local tag = best_tag(function(e) return e.first end, function(e) return e.raw_first end)
+                 or best_tag(function(e) return e.last  end, function(e) return e.raw_last  end)
+        return tag, entries
+    end
+
+    local alpha_tag, alpha_entries = build_and_detect(alpha_list)
+    local beta_tag,  beta_entries  = build_and_detect(beta_list)
+
+    local api_tags = {}
+    do
+        local lookup = {}
+        if not alpha_tag and alpha_entries then lookup[#lookup + 1] = alpha_entries[1].guid end
+        if not beta_tag  and beta_entries  then lookup[#lookup + 1] = beta_entries[1].guid  end
+        if #lookup > 0 then
+            api_tags = utils.fetch_player_tags(lookup, _api_token, _players_url, http_ref)
+        end
+    end
+
+    local function resolve(tag, entries)
+        if tag then return tag, "tag", nil end
+        if not entries then return nil, "empty", nil end
+        local api_tag = api_tags[entries[1].guid]
+        if api_tag then return api_tag, "api", entries[1].raw end
+        return "[" .. entries[1].raw .. "^7]", "fallback", entries[1].raw
+    end
+
+    local alpha_source, alpha_raw
+    local beta_source,  beta_raw
+    _alpha_name, alpha_source, alpha_raw = resolve(alpha_tag, alpha_entries)
+    _beta_name,  beta_source,  beta_raw  = resolve(beta_tag,  beta_entries)
+
+    local function warn_fallback(team_label, source, name, raw)
+        if source == "tag" then return end
+        local clean = raw and utils.strip_colors(raw):match("^%s*(.-)%s*$") or "?"
+        utils.say(string.format("^7Couldn't determine tag for ^3%s", team_label))
+        if source == "api" then
+            utils.say(string.format("^7Using registered tag from ^3%s^7:", clean))
+        else
+            utils.say(string.format("^7Using player name ^3%s^7:", utils.strip_colors(name)))
+        end
+    end
+    warn_fallback("Axis",   alpha_source, _alpha_name, alpha_raw)
+    warn_fallback("Allies", beta_source,  _beta_name,  beta_raw)
+
+    _match_id  = tostring(os.time())
+    _is_active = true
+
+    if scores_ref then scores_ref.activate_ng_mode(_match_id, _alpha_name, _beta_name) end
+
+    if log then
+        log.write(string.format("ng: new match — match_id=%s axis=%d allies=%d alpha_name=%s beta_name=%s",
+            _match_id, #alpha_list, #beta_list,
+            utils.strip_colors(_alpha_name or "nil"),
+            utils.strip_colors(_beta_name  or "nil")))
+    end
+end
+
+
+function ng_scores.save_to_file()
+    if not _match_id then return false end
+
+    local dir = utils.get_team_data_dir()
+    if not dir then
+        if log then log.write("ng: save_to_file — cannot resolve team data dir") end
+        return false
+    end
+
+    local path = string.format("%s/%s_team_data.json", dir, _match_id)
+
+    local alpha_players = {}
+    for g in pairs(_alpha_guids) do
+        alpha_players[#alpha_players + 1] = { GUID = { g } }
+    end
+    local beta_players = {}
+    for g in pairs(_beta_guids) do
+        beta_players[#beta_players + 1] = { GUID = { g } }
+    end
+
+    local data = {
+        match_id       = _match_id,
+        ng             = true,
+        alpha_teamname = _alpha_name,
+        beta_teamname  = _beta_name,
+        match          = { alpha_team = alpha_players, beta_team = beta_players },
+        match_extra    = {},
+        last_updated   = et.trap_Milliseconds(),
+        scores_state   = scores_ref and scores_ref.get_state_for_persistence() or nil,
+    }
+
+    local jstr = json.encode(data)
+    if not jstr then return false end
+
+    local ok = pcall(function()
+        local f = io.open(path, "w")
+        if not f then error("cannot open " .. path) end
+        f:write(jstr)
+        f:close()
+    end)
+
+    if ok and log then
+        log.write(string.format("ng: team data saved — match_id=%s axis=%d allies=%d",
+            _match_id, #alpha_players, #beta_players))
+    end
+    return ok
+end
+
+
+function ng_scores.load_from_file()
+    if not _auto_scores then return false end
+
+    local dir = utils.get_team_data_dir()
+    if not dir then return false end
+
+    local path
+    if _match_id then
+        path = string.format("%s/%s_team_data.json", dir, _match_id)
+    else
+        local ok, f = pcall(io.popen,
+            string.format('ls -t "%s"/*_team_data.json 2>/dev/null', dir))
+        if ok and f then
+            for candidate in f:lines() do
+                local rok, rdata = pcall(function()
+                    local rf = io.open(candidate, "r")
+                    if not rf then return nil end
+                    local content = rf:read("*all")
+                    rf:close()
+                    if not content or content == "" then return nil end
+                    return json.decode(content)
+                end)
+                if rok and rdata and rdata.ng then
+                    path = candidate
+                    break
+                end
+            end
+            f:close()
+        end
+    end
+
+    if not path then return false end
+
+    local ok, result = pcall(function()
+        local f = io.open(path, "r")
+        if not f then return nil end
+        local content = f:read("*all")
+        f:close()
+        if not content or content == "" then return nil end
+        return json.decode(content)
+    end)
+
+    if not (ok and result and result.ng and result.match_id) then return false end
+
+    _match_id    = result.match_id
+    _alpha_name  = result.alpha_teamname or nil
+    _beta_name   = result.beta_teamname  or nil
+    _alpha_guids = {}
+    _beta_guids  = {}
+
+    for _, p in ipairs((result.match and result.match.alpha_team) or {}) do
+        for _, g in ipairs(p.GUID or {}) do _alpha_guids[string.upper(g)] = true end
+    end
+    for _, p in ipairs((result.match and result.match.beta_team) or {}) do
+        for _, g in ipairs(p.GUID or {}) do _beta_guids[string.upper(g)] = true end
+    end
+
+    if scores_ref then
+        scores_ref.activate_ng_mode(_match_id, _alpha_name, _beta_name)
+        if result.scores_state then
+            scores_ref.restore_state(result.scores_state)
+        end
+    end
+
+    _is_active = true
+
+    if log then
+        log.write(string.format("ng: match loaded from file — match_id=%s", _match_id))
+    end
+    return true
+end
+
+
+return ng_scores

--- a/luascripts/stats/ng_scores.lua
+++ b/luascripts/stats/ng_scores.lua
@@ -78,11 +78,6 @@ function ng_scores.is_active()
 end
 
 
-function ng_scores.get_match_id()
-    return _match_id
-end
-
-
 local function check_continuity()
     local stored = {}
     for g in pairs(_alpha_guids) do stored[g] = true end

--- a/luascripts/stats/scores.lua
+++ b/luascripts/stats/scores.lua
@@ -38,6 +38,7 @@ local gamestate_ref
 
 local _auto_scores = false
 local _eff_scores  = false
+local _ng_mode     = false
 
 local _match_id        = nil
 local _alpha_team      = nil   -- alpha roster; used for team-side validation
@@ -92,6 +93,7 @@ function scores.reset_match()
     _fullhold_buffer = {}
     _alpha_teamname  = nil
     _beta_teamname   = nil
+    _ng_mode         = false
     if log then log.write("scores: match state reset") end
 end
 
@@ -120,6 +122,22 @@ function scores.update_match_data(match_id, match_data, features)
         log.write(string.format(
             "scores: match_data updated — match_id=%s eff_scores=%s",
             tostring(match_id), tostring(_eff_scores)))
+    end
+end
+
+
+-- alpha_name / beta_name are raw player names captured at match start.
+function scores.activate_ng_mode(match_id, alpha_name, beta_name)
+    if match_id and (not _match_id or match_id ~= _match_id) then
+        scores.reset_match()
+    end
+    _match_id       = match_id
+    _eff_scores     = true
+    _ng_mode        = true
+    _alpha_teamname = alpha_name or _alpha_teamname
+    _beta_teamname  = beta_name  or _beta_teamname
+    if log then
+        log.write(string.format("scores: ng mode activated — match_id=%s", tostring(match_id)))
     end
 end
 
@@ -179,42 +197,25 @@ end
 
 
 local function build_alpha_guid_set()
-    local set = {}
-    if not _alpha_team then return set end
-    for _, player in ipairs(_alpha_team) do
-        if player.GUID then
-            for _, g in ipairs(player.GUID) do
-                set[string.upper(g)] = true
-            end
-        end
-    end
-    return set
+    if not _alpha_team then return {} end
+    return utils.build_guid_set(_alpha_team)
 end
 
 
--- Scan connected players, count how many alpha roster members are on each team.
+-- Scan connected players (teams only), count how many alpha roster members are on each team.
 local function detect_alpha_side_from_players()
     local alpha_guid_set = build_alpha_guid_set()
     if not next(alpha_guid_set) then return nil end
 
-    local maxC = tonumber(et.trap_Cvar_Get("sv_maxclients")) or 24
     local on_axis   = 0
     local on_allies = 0
     local total     = 0
 
-    for i = 0, maxC - 1 do
-        if et.gentity_get(i, "pers.connected") == 2 then
-            local userinfo = et.trap_GetUserinfo(i)
-            if userinfo and userinfo ~= "" then
-                local guid = string.upper(
-                    et.Info_ValueForKey(userinfo, "cl_guid") or "")
-                if alpha_guid_set[guid] then
-                    total = total + 1
-                    local team = tonumber(et.gentity_get(i, "sess.sessionTeam")) or 0
-                    if team == TEAM_AXIS   then on_axis   = on_axis   + 1 end
-                    if team == TEAM_ALLIES then on_allies = on_allies + 1 end
-                end
-            end
+    for _, p in ipairs(utils.get_connected_players()) do
+        if alpha_guid_set[p.guid] then
+            total = total + 1
+            if p.team == TEAM_AXIS   then on_axis   = on_axis   + 1 end
+            if p.team == TEAM_ALLIES then on_allies = on_allies + 1 end
         end
     end
 
@@ -283,9 +284,10 @@ local function process_r1(map_num, alpha_won, fullhold)
     -- Clinch is ONLY valid at exactly 3-0: one team has 3 points and the
     -- other has 0. Only reachable via: win map1 cleanly (+2) then hold R1
     -- of map2 for the full timelimit (+1 provisional = 3-0).
+    -- Suppressed in ng mode — scores accumulate indefinitely.
     local clinch = (_alpha_score == 3 and _beta_score == 0)
                 or (_beta_score == 3 and _alpha_score == 0)
-    if clinch then
+    if clinch and not _ng_mode then
         _match_finished = true
         _match_winner   = _alpha_score > _beta_score and "alpha" or "beta"
         if log then
@@ -343,12 +345,15 @@ local function process_r2(map_num, alpha_won, fullhold)
         end
     end
 
+    -- Match termination suppressed in ng mode — scores accumulate indefinitely.
     local completed_maps = map_num
-    if completed_maps >= 2 and (_alpha_score >= 3 or _beta_score >= 3) then
-        _match_finished = true
-    end
-    if completed_maps >= 3 then
-        _match_finished = true
+    if not _ng_mode then
+        if completed_maps >= 2 and (_alpha_score >= 3 or _beta_score >= 3) then
+            _match_finished = true
+        end
+        if completed_maps >= 3 then
+            _match_finished = true
+        end
     end
 
     if _match_finished then

--- a/luascripts/stats/scores.lua
+++ b/luascripts/stats/scores.lua
@@ -541,8 +541,4 @@ function scores.is_finished()
     return _match_finished
 end
 
-function scores.get_winner()
-    return _match_winner
-end
-
 return scores

--- a/luascripts/stats/scores.lua
+++ b/luascripts/stats/scores.lua
@@ -57,12 +57,11 @@ local _fullhold_buffer = {}
 local TEAM_AXIS   = 1
 local TEAM_ALLIES = 2
 
--- [map_num][round_num] → expected ET team for alpha (1=axis, 2=allies)
-local ALPHA_SIDE_TABLE = {
-    [1] = { [1] = 1, [2] = 2 },
-    [2] = { [1] = 2, [2] = 1 },
-    [3] = { [1] = 1, [2] = 2 },
-}
+-- alpha is axis when (map_num + round_num) is even, allies otherwise.
+-- map1r1=axis(even), map1r2=allies(odd), map2r1=allies(odd), map2r2=axis(even), etc.
+local function alpha_expected_side(map_num, round_num)
+    return ((map_num + round_num) % 2 == 0) and TEAM_AXIS or TEAM_ALLIES
+end
 
 local VALIDATION_THRESHOLD = 0.8   -- 80% of scanned alpha players must confirm side
 
@@ -234,7 +233,7 @@ end
 
 
 local function resolve_alpha_side(map_num, round_num)
-    local expected = (ALPHA_SIDE_TABLE[map_num] or {})[round_num] or TEAM_AXIS
+    local expected = alpha_expected_side(map_num, round_num)
 
     local detected = detect_alpha_side_from_players()
     if detected then
@@ -336,11 +335,14 @@ local function process_r2(map_num, alpha_won, fullhold)
                 alpha_won and "alpha" or "beta", _alpha_score, _beta_score))
         end
     else
-        _alpha_score = _alpha_score + 1
-        _beta_score  = _beta_score  + 1
+        if alpha_won then
+            _alpha_score = _alpha_score + 2
+        else
+            _beta_score  = _beta_score  + 2
+        end
         if log then
             log.write(string.format(
-                "scores: no R1 data for map %d — awarding +1 each as fallback (score %d-%d)",
+                "scores: no R1 data for map %d — awarding +2 to R2 winner as fallback (score %d-%d)",
                 map_num, _alpha_score, _beta_score))
         end
     end
@@ -464,6 +466,8 @@ function scores.get_metadata(round_info)
         info.scores = {
             alpha          = _alpha_score,
             beta           = _beta_score,
+            alpha_teamname = _alpha_teamname or nil,
+            beta_teamname  = _beta_teamname  or nil,
             completed_maps = math.floor(#_round_buffer / 2),
             match_finished = _match_finished,
             match_winner   = _match_winner or nil,
@@ -498,6 +502,11 @@ function scores.get_match_id()
     return _match_id
 end
 
+function scores.set_match_id(id)
+    _match_id = id
+end
+
+
 function scores.get_last_round()
     if #_round_buffer == 0 then return nil end
     return _round_buffer[#_round_buffer]
@@ -515,7 +524,6 @@ end
 
 function scores.announce_score()
     if not _eff_scores then return end
-    if _alpha_score == 0 and _beta_score == 0 then return end
     if gamestate_ref and gamestate_ref.current ~= et.GS_INTERMISSION then return end
 
     local alpha_name = clean_teamname(_alpha_teamname) or "Alpha"

--- a/luascripts/stats/stats.lua
+++ b/luascripts/stats/stats.lua
@@ -156,7 +156,9 @@ end
 function stats.save(round_start_time, round_end_time, round_start_unix, round_end_unix,
                     server_ip, server_port)
 
-    local match_id = api_ref and api_ref.fetch_match_id() or tostring(os.time())
+    local match_id = (scores_ref and scores_ref.get_match_id())
+                  or (api_ref and api_ref.fetch_match_id())
+                  or tostring(os.time())
 
     local mapname = et.Info_ValueForKey(
         et.trap_GetConfigstring(et.CS_SERVERINFO), "mapname")

--- a/luascripts/stats/util/utils.lua
+++ b/luascripts/stats/util/utils.lua
@@ -145,4 +145,97 @@ function utils.cp(msg)
     et.trap_SendServerCommand(-1, "cp \"" .. msg .. "\"")
 end
 
+
+-- Returns array of { guid=string(upper), team=number, clientNum=number }
+-- for every connected player on teams 1 (axis) or 2 (allies).
+-- Spectators (team 3+) are always excluded.
+function utils.get_connected_players(maxClients)
+    maxClients = maxClients or (tonumber(et.trap_Cvar_Get("sv_maxclients")) or 24)
+    local players = {}
+    for i = 0, maxClients - 1 do
+        if et.gentity_get(i, "pers.connected") == 2 then
+            local team = tonumber(et.gentity_get(i, "sess.sessionTeam")) or 0
+            if team == 1 or team == 2 then
+                local userinfo = et.trap_GetUserinfo(i)
+                if userinfo and userinfo ~= "" then
+                    local guid = string.upper(et.Info_ValueForKey(userinfo, "cl_guid") or "")
+                    if guid ~= "" then
+                        players[#players + 1] = { guid = guid, team = team, clientNum = i }
+                    end
+                end
+            end
+        end
+    end
+    return players
+end
+
+
+function utils.build_guid_set(team_array)
+    local set = {}
+    for _, player in ipairs(team_array or {}) do
+        for _, g in ipairs(player.GUID or {}) do
+            set[string.upper(g)] = true
+        end
+    end
+    return set
+end
+
+
+function utils.guid_overlap(guid_set, players_array)
+    local set_size = 0
+    for _ in pairs(guid_set) do set_size = set_size + 1 end
+    local count = 0
+    for _, p in ipairs(players_array) do
+        if guid_set[p.guid] then count = count + 1 end
+    end
+    local denom = math.max(set_size, #players_array)
+    return count, (denom > 0 and count / denom or 0)
+end
+
+
+function utils.fetch_player_tags(guids, api_token, players_url, http_module)
+    if not http_module or not players_url or not players_url:find("^https?://") then return {} end
+    if not guids or #guids == 0 then return {} end
+
+    local parts = {}
+    for _, g in ipairs(guids) do
+        parts[#parts + 1] = "guid=" .. g
+    end
+    local url = players_url .. "?" .. table.concat(parts, "&")
+    local cmd = string.format(
+        "curl -H \"Authorization: Bearer %s\"" ..
+        " --connect-timeout 1 --max-time 1 --retry 0 --silent --compressed \"%s\"",
+        api_token or "", url)
+
+    local result = http_module.sync(cmd)
+    if type(result) ~= "table" then return {} end
+
+    local out = {}
+    for _, v in ipairs(result) do
+        if type(v) == "table" and type(v.guid) == "string" then
+            local raw_tag = v.user_tag_no_separator or v.user_tag
+            if raw_tag and raw_tag ~= "" then
+                -- Tags are comma-separated; strip {name}, split, pick one at random
+                local candidates = {}
+                for t in raw_tag:gmatch("[^,]+") do
+                    t = t:gsub("{name}", ""):match("^%s*(.-)%s*$")
+                    if t ~= "" then candidates[#candidates + 1] = t end
+                end
+                if #candidates > 0 then
+                    out[v.guid:upper()] = candidates[math.random(#candidates)]
+                end
+            end
+        end
+    end
+    return out
+end
+
+
+function utils.get_team_data_dir()
+    local fs_basepath = et.trap_Cvar_Get("fs_basepath")
+    local fs_game     = et.trap_Cvar_Get("fs_game")
+    if not fs_basepath or not fs_game then return nil end
+    return string.format("%s/%s/luascripts", fs_basepath, fs_game)
+end
+
 return utils


### PR DESCRIPTION
Added some minor prefix/suffix team tag detection methods for more intuitive score output on chat. Requires STATS_AUTO_SCORES=true (default)