### PR TITLE
Track item pickups in gamelog. 

### DIFF
--- a/luascripts/README.md
+++ b/luascripts/README.md
@@ -266,6 +266,20 @@ Ordered array of all events that occurred during the round. Every entry has:
 | `player` | GUID |
 | `flag` | Flag name (`allies_flag`, `axis_flag`, or config key) |
 
+**`pickup`** — console-log pickup/use event
+
+`Item:` is the canonical pickup/use signal. When `Ammo_Pack:` or `Health_Pack:` appears on the same log frame, it attributes that same pickup to another player's pack instead of creating a second event.
+
+| Field | Description |
+|-------|-------------|
+| `player` | GUID |
+| `item` | Raw item token from the log, e.g. `item_health`, `weapon_magicammo`, `weapon_mp40`, `weapon_thompson` |
+| `owner` | GUID of the player whose health/ammo pack was used (optional; absent for self-use and generic weapon pickups) |
+| `pos` | `"x y z"` player origin at the time the line was processed |
+| `stance` | Stance snapshot for the acting player |
+| `owner_pos` | `"x y z"` owner origin at the time the line was processed (optional) |
+| `owner_stance` | Owner stance snapshot (optional) |
+
 **`shove`**
 
 | Field | Description |
@@ -291,7 +305,7 @@ Ordered array of all events that occurred during the round. Every entry has:
 | `round_start` | Emitted when gamestate transitions to GS_PLAYING |
 | `round_end` | Emitted when gamestate transitions to GS_INTERMISSION |
 
-**Stance snapshot** (embedded in kill / teamkill / damage / weapon_fire events):
+**Stance snapshot** (embedded in kill / teamkill / damage / pickup / weapon_fire events):
 
 ```json
 {
@@ -561,6 +575,18 @@ interface FlagCapturedEvent extends GamelogEventBase {
   flag:   string;
 }
 
+interface PickupEvent extends GamelogEventBase {
+  group:  "player";
+  label:  "pickup";
+  player: Guid;
+  item:   string;
+  owner?: Guid;
+  pos:    Position | null;
+  stance: StanceSnapshot | null;
+  owner_pos:     Position | null;
+  owner_stance:  StanceSnapshot | null;
+}
+
 interface ShoveEvent extends GamelogEventBase {
   group:  "player";
   label:  "shove";
@@ -585,7 +611,7 @@ interface RoundEndEvent   extends GamelogEventBase { group: "server"; label: "ro
 type GamelogEvent =
   | SpawnEvent | KillEvent | SuicideEvent | TeamkillEvent | DamageEvent
   | ReviveEvent | ClassChangeEvent | MessageEvent
-  | ObjectiveEvent | FlagCapturedEvent | ShoveEvent
+  | ObjectiveEvent | FlagCapturedEvent | PickupEvent | ShoveEvent
   | WeaponFireEvent
   | RoundStartEvent | RoundEndEvent;
 

--- a/luascripts/stats.lua
+++ b/luascripts/stats.lua
@@ -1,6 +1,6 @@
 --[[
     stats.lua  — root module for ETLegacy game stats collection
-    Version: 2.2.2
+    Version: 2.2.3
 
     All user-facing settings live in the CONFIGURATION block below.
     config.toml is kept only for map-specific patterns and common buildables.
@@ -63,7 +63,7 @@ local SAVE_STATS_DELAY          = 3000   -- ms after intermission before SaveSta
 
 -- [MODULE]
 local MODNAME                   = "stats"
-local VERSION                   = "2.2.2"
+local VERSION                   = "2.2.3"
 
 -- [ENV OVERRIDES]
 -- Any setting above can be overridden by an environment variable of the same

--- a/luascripts/stats/gamelog.lua
+++ b/luascripts/stats/gamelog.lua
@@ -160,6 +160,19 @@ function gamelog.obj_flag_captured(guid, flag_name)
     })
 end
 
+-- Pickup from console log
+function gamelog.pickup(player_snap, item, owner_snap)
+    gamelog.record("pickup", "player", {
+        player       = player_snap and player_snap.guid,
+        item         = item,
+        owner        = owner_snap and owner_snap.guid or nil,
+        pos          = utils.fmt_pos(player_snap and player_snap.pos),
+        stance       = stance_of(player_snap),
+        owner_pos    = utils.fmt_pos(owner_snap and owner_snap.pos),
+        owner_stance = stance_of(owner_snap),
+    })
+end
+
 -- Player spawn (not a revive)
 -- weapons: array of notable weapon name strings present at spawn, or nil
 function gamelog.spawn(guid, team, class, weapons)

--- a/luascripts/stats/objectives.lua
+++ b/luascripts/stats/objectives.lua
@@ -34,10 +34,64 @@ local recent_announcements  = {}
 local ANNOUNCE_BUFFER       = 5
 local REPAIR_BUFFER_MS      = 2000
 local MAX_OBJ_DISTANCE      = 500  -- game units
+local pending_pickup        = nil
 
 -- Active map config
 local _map_config           = nil
 local _common_buildables    = nil
+
+
+local function flush_pending_pickup()
+    if pending_pickup and _collect_gamelog and gamelog_ref and pending_pickup.player_snap then
+        gamelog_ref.pickup(pending_pickup.player_snap, pending_pickup.item, pending_pickup.owner_snap)
+    end
+    pending_pickup = nil
+end
+
+
+local function queue_item_pickup(clientNum, item)
+    local entry = players_ref.guids[clientNum]
+    if not entry or not entry.guid or entry.guid == "WORLD" then return end
+
+    pending_pickup = {
+        clientNum   = clientNum,
+        item        = item,
+        player_snap = players_ref.get_snapshot(clientNum) or { guid = entry.guid },
+        owner_snap  = nil,
+    }
+end
+
+
+local function emit_direct_pickup(player_id, owner_id, item)
+    local player_entry = players_ref.guids[player_id]
+    if not player_entry or not player_entry.guid or player_entry.guid == "WORLD" then return end
+
+    local player_snap = players_ref.get_snapshot(player_id) or { guid = player_entry.guid }
+    local owner_entry = owner_id and players_ref.guids[owner_id] or nil
+    local owner_snap  = owner_entry and owner_entry.guid and owner_entry.guid ~= "WORLD"
+        and (players_ref.get_snapshot(owner_id) or { guid = owner_entry.guid })
+        or nil
+
+    if _collect_gamelog and gamelog_ref then
+        gamelog_ref.pickup(player_snap, item, owner_snap)
+    end
+end
+
+
+local function attach_pickup_owner(owner_id, player_id, item)
+    if pending_pickup
+    and pending_pickup.clientNum == player_id
+    and pending_pickup.item == item then
+        local owner_entry = players_ref.guids[owner_id]
+        pending_pickup.owner_snap = owner_entry and owner_entry.guid and owner_entry.guid ~= "WORLD"
+            and (players_ref.get_snapshot(owner_id) or { guid = owner_entry.guid })
+            or nil
+        flush_pending_pickup()
+        return
+    end
+
+    emit_direct_pickup(player_id, owner_id, item)
+end
 
 
 local function record_obj_stat(guid, event_type, objective, killer_info)
@@ -376,10 +430,62 @@ end
 
 
 function objectives.handle_print(text)
+    local current_time = et.trap_Milliseconds()
+    local _ = current_time
+
+    -- Gamelog-only pickup events are coalesced from adjacent Item + pack-owner lines.
+    if _collect_gamelog and gamelog_ref and string.find(text, "Ammo_Pack:", 1, true) then
+        local owner_str, player_str = text:match("Ammo_Pack:%s*(%d+)%s+(%d+)")
+        if player_str and owner_str then
+            attach_pickup_owner(tonumber(owner_str), tonumber(player_str), "weapon_magicammo")
+            return
+        end
+    end
+
+    if _collect_gamelog and gamelog_ref and string.find(text, "Health_Pack:", 1, true) then
+        local owner_str, player_str = text:match("Health_Pack:%s*(%d+)%s+(%d+)")
+        if player_str and owner_str then
+            attach_pickup_owner(tonumber(owner_str), tonumber(player_str), "item_health")
+            return
+        end
+    end
+
+    if pending_pickup then
+        flush_pending_pickup()
+    end
+
+    if _collect_gamelog and gamelog_ref and string.find(text, "Item:", 1, true) then
+        local id_str, item = text:match("Item:%s*(%d+)%s+(%S+)")
+        if id_str and item
+        and item ~= "team_CTF_redflag"
+        and item ~= "team_CTF_blueflag"
+        and (item == "item_health" or item == "weapon_magicammo" or string.find(item, "^weapon_")) then
+            queue_item_pickup(tonumber(id_str), item)
+            return
+        end
+    end
+
+    -- Shove tracking does not depend on map objective config either.
+    if _collect_shovestats and string.find(text, "Shove:", 1, true) then
+        local shover_str, target_str = text:match("^Shove: (%d+) (%d+)")
+        if shover_str then
+            local shover_entry = players_ref.guids[tonumber(shover_str)]
+            local target_entry = players_ref.guids[tonumber(target_str)]
+            if shover_entry and target_entry then
+                local shover_guid = shover_entry.guid
+                local target_guid = target_entry.guid
+                record_obj_stat(shover_guid, "shoves_given",    target_guid)
+                record_obj_stat(target_guid, "shoves_received", shover_guid)
+
+                if _collect_gamelog and gamelog_ref then
+                    gamelog_ref.shove(shover_guid, target_guid)
+                end
+            end
+        end
+    end
+
     if not _map_config then return end
     if not _collect_objstats then return end
-
-    local current_time = et.trap_Milliseconds()
 
     -- Objective_Destroyed: <id> <text>
     if string.find(text, "Objective_Destroyed:", 1, true) then
@@ -716,24 +822,6 @@ function objectives.handle_print(text)
         end
     end
 
-    -- Shove: <shover_id> <target_id>
-    if _collect_shovestats and string.find(text, "Shove:", 1, true) then
-        local shover_str, target_str = text:match("^Shove: (%d+) (%d+)")
-        if shover_str then
-            local shover_entry = players_ref.guids[tonumber(shover_str)]
-            local target_entry = players_ref.guids[tonumber(target_str)]
-            if shover_entry and target_entry then
-                local shover_guid = shover_entry.guid
-                local target_guid = target_entry.guid
-                record_obj_stat(shover_guid, "shoves_given",    target_guid)
-                record_obj_stat(target_guid, "shoves_received", shover_guid)
-
-                if _collect_gamelog and gamelog_ref then
-                    gamelog_ref.shove(shover_guid, target_guid)
-                end
-            end
-        end
-    end
 end
 
 
@@ -770,11 +858,18 @@ function objectives.get_stats()
 end
 
 
+function objectives.flush_pending_gamelog()
+    flush_pending_pickup()
+end
+
+
 function objectives.reset()
+    flush_pending_pickup()
     objectives.objstats  = {}
     objective_carriers   = { players = {}, ids = {} }
     objective_states     = {}
     recent_announcements = {}
+    pending_pickup       = nil
     _map_config          = nil
     _common_buildables   = nil
 end

--- a/luascripts/stats/stats.lua
+++ b/luascripts/stats/stats.lua
@@ -280,6 +280,9 @@ function stats.save(round_start_time, round_end_time, round_start_unix, round_en
 
     local gamelog_data = nil
     if _collect_gamelog and gamelog_ref then
+        if objectives_ref and objectives_ref.flush_pending_gamelog then
+            objectives_ref.flush_pending_gamelog()
+        end
         gamelog_data = gamelog_ref.get(match_id, round)
     end
 


### PR DESCRIPTION
Currently uses console.log, should definitely be updated in the future if/when callbacks get added. Log only has  pickup events.  Throw/drop, despawns or enemy-pickup are not logged.