### PR TITLE
refactor objective attribution, add vehicle/escort/carrier tracking

### DIFF
--- a/luascripts/README.md
+++ b/luascripts/README.md
@@ -924,8 +924,8 @@ The match-ID endpoint is called as `GET {API_URL_MATCHID}/{server_ip}/{server_po
 | `COLLECT_MOVEMENT_STATS` | `true` | Distance travelled and speed in `player_stats` |
 | `COLLECT_STANCE_STATS` | `true` | Stance-time breakdown in `player_stats` |
 | `COLLECT_VEHICLE_STATS` | `true` | Entity-state escort vehicle tracking: per-player escort credit (`player_stats.obj_vehicle.escort`) and `vehicle_*` timeline events in `gamelog`. Active only on maps with an `escort` config section — its entry names (or `script_name` keys) pin the vehicle script_movers; maps without one have no vehicle and are skipped entirely. |
-| `COLLECT_VEHICLE_TELEMETRY` | `false` | 1-second position samples for moving vehicles (`vehicle_pos`) and objective carriers (`carrier_pos`). Higher volume — enable when route replay is wanted. |
-| `COLLECT_VEHICLE_DAMAGE` | `false` | Per-player damage tracking for damageable objectives: `vehicle_damage` events + `player_stats.obj_vehicle.damage` / `.repairs` for vehicles, and `obj_damage` events for constructibles (command posts, destroyable walls). Trucks are not damageable and never emit these. |
+| `COLLECT_VEHICLE_TELEMETRY` | `true` | 1-second position samples for moving vehicles (`vehicle_pos`) and objective carriers (`carrier_pos`), enabling route replay. Modest volume (~200 events per escort round). |
+| `COLLECT_VEHICLE_DAMAGE` | `true` | Per-player damage tracking for damageable objectives: `vehicle_damage` events + `player_stats.obj_vehicle.damage` / `.repairs` for vehicles, and `obj_damage` events for constructibles (command posts, destroyable walls). Trucks are not damageable and never emit these. |
 
 ### [OUTPUT]
 

--- a/luascripts/README.md
+++ b/luascripts/README.md
@@ -346,22 +346,25 @@ vehicles (script_movers), enabled by `COLLECT_VEHICLE_STATS`. All carry a `vehic
 | `vehicle_damaged` | `player?`, `pos` | Health hit 0 (disabled); `player` = last damager if attributable |
 | `vehicle_repaired` | `player?`, `pos` | Health restored; `player` = repairing engineer via `Repair:` line |
 | `vehicle_pos` | `pos`, `escorts?` | 1s position sample while moving (`COLLECT_VEHICLE_TELEMETRY` only) |
-| `vehicle_damage` | `player`, `damage` | Per-hit vehicle damage (`COLLECT_VEHICLE_DAMAGE` only) |
+| `vehicle_damage` | `player`, `damage` | Per-hit vehicle damage, clamped to the vehicle's remaining health (`COLLECT_VEHICLE_DAMAGE` only) |
 | `vehicle_finale` | `pos`, `escorts?` | The map's escort announce fired (destination reached); `escorts` = owning-team players at the destination |
 | `vehicle_summary` | `total_distance`, `moving_time_s`, `damaged_count`, `repaired_count` | One per vehicle that entered play, at round end |
 
 `escorts` is the array of player GUIDs accruing escort credit at that moment (alive,
 escorting team, within the escort radius while the vehicle moves); omitted when empty.
 
-**`obj_damage`** — damage to a non-vehicle damageable objective (command post, destroyable
-walls); `COLLECT_VEHICLE_DAMAGE` only. Trucks never emit damage events — they are not
-damageable (`takedamage 0`), so the engine never fires the damage hook for them. Only hits
-that pass the engine's per-entity weapon-class gate arrive here, so volume is low.
+**`obj_damage`** — damage to a non-vehicle damageable objective (command post, breach walls,
+barriers); `COLLECT_VEHICLE_DAMAGE` only. Restricted to `ET_CONSTRUCTIBLE` entities — the
+engine fires the damage hook for every damageable entity, so corpse gib damage (`ET_CORPSE`)
+and decorative breakables (`func_explosive`, `props_*` chairs/windows/paintings) are filtered
+out here rather than polluting the stream. `damage` is clamped to the objective's remaining
+health so an overkill (e.g. an airstrike on a near-dead wall) reports only the fraction that
+landed. Trucks never emit these: they are not damageable (`takedamage 0`).
 
 | Field | Description |
 |-------|-------------|
 | `player` | Attacker GUID |
-| `damage` | Damage amount |
+| `damage` | Damage dealt, clamped to the objective's remaining health |
 | `target` | Entity name (objective `track`, falling back to scriptName/classname) |
 
 **`carrier_pos`** — objective-carrier position sample (`COLLECT_VEHICLE_TELEMETRY` only)
@@ -757,12 +760,13 @@ interface VehiclePosEvent      extends VehicleEventBase { label: "vehicle_pos"; 
 interface VehicleDamageEvent   extends VehicleEventBase { label: "vehicle_damage";   player: Guid; damage: number; }  // COLLECT_VEHICLE_DAMAGE
 interface VehicleFinaleEvent   extends VehicleEventBase { label: "vehicle_finale";   pos: Position; escorts?: Guid[]; }
 
-// COLLECT_VEHICLE_DAMAGE: damage to non-vehicle damageable objectives (CP, walls)
+// COLLECT_VEHICLE_DAMAGE: damage to ET_CONSTRUCTIBLE objectives (CP, breach
+// walls, barriers). Corpses and decorative breakables are filtered out.
 interface ObjDamageEvent extends GamelogEventBase {
   group:  "player";
   label:  "obj_damage";
   player: Guid;
-  damage: number;
+  damage: number;  // clamped to the objective's remaining health
   target: string;  // objective track name, falling back to scriptName/classname
 }
 interface VehicleSummaryEvent  extends VehicleEventBase {
@@ -925,7 +929,7 @@ The match-ID endpoint is called as `GET {API_URL_MATCHID}/{server_ip}/{server_po
 | `COLLECT_STANCE_STATS` | `true` | Stance-time breakdown in `player_stats` |
 | `COLLECT_VEHICLE_STATS` | `true` | Entity-state escort vehicle tracking: per-player escort credit (`player_stats.obj_vehicle.escort`) and `vehicle_*` timeline events in `gamelog`. Active only on maps with an `escort` config section — its entry names (or `script_name` keys) pin the vehicle script_movers; maps without one have no vehicle and are skipped entirely. |
 | `COLLECT_VEHICLE_TELEMETRY` | `true` | 1-second position samples for moving vehicles (`vehicle_pos`) and objective carriers (`carrier_pos`), enabling route replay. Modest volume (~200 events per escort round). |
-| `COLLECT_VEHICLE_DAMAGE` | `true` | Per-player damage tracking for damageable objectives: `vehicle_damage` events + `player_stats.obj_vehicle.damage` / `.repairs` for vehicles, and `obj_damage` events for constructibles (command posts, destroyable walls). Trucks are not damageable and never emit these. |
+| `COLLECT_VEHICLE_DAMAGE` | `true` | Per-player damage tracking for damageable objectives: `vehicle_damage` events + `player_stats.obj_vehicle.damage` / `.repairs` for vehicles, and `obj_damage` events for `ET_CONSTRUCTIBLE` objectives (command posts, breach walls, barriers). Corpse gibs and decorative breakables are filtered out; damage is clamped to remaining health. Trucks are not damageable and never emit these. |
 
 ### [OUTPUT]
 

--- a/luascripts/README.md
+++ b/luascripts/README.md
@@ -68,15 +68,32 @@ Keyed by GUID. Each entry includes:
 | `obj_defused` | object | Same |
 | `obj_destroyed` | object | Same |
 | `obj_repaired` | object | Same |
-| `obj_taken` | object | Same |
+| `obj_taken` | object | Same — initial steal from the objective's stand |
+| `obj_repickup` | object | Same — re-pickup of a dropped objective (distinct from the initial steal) |
+| `obj_dropped` | object | Same — carrier died, disconnected, or dropped manually (`+dropobj`) while holding the objective |
 | `obj_secured` | object | Same |
 | `obj_returned` | object | Same |
-| `obj_carrierkilled` | object | `{ leveltime: { victim, weapon, objective, timestamp_unix } }` |
+| `obj_carrierkilled` | object | `{ leveltime: { victim, weapon, objective, timestamp_unix } }` — credited to the **killer** of an enemy objective carrier; `victim` is the carrier's GUID. Selfkills/teamkills/world deaths never produce this (the carrier's side is `obj_dropped`). |
 | `obj_flagcaptured` | object | `{ leveltime: { objective, timestamp_unix } }` |
 | `obj_misc` | object | Same |
-| `obj_escort` | object | Same |
 | `shoves_given` | object | `{ leveltime: { objective (target GUID), timestamp_unix } }` |
 | `shoves_received` | object | Same |
+| `obj_vehicle` | object | `COLLECT_VEHICLE_STATS` per-player vehicle stats (see below) |
+
+> **Deprecation notice:** `obj_escort` (one-shot proximity attribution at the map's escort
+> announce) was removed in 2.7.0. Its replacement is `obj_vehicle.escort` — cumulative
+> per-vehicle time/distance — which tells the whole story instead of a single snapshot.
+> The point-in-time facts moved to the gamelog: `vehicle_started.escorts` = who was there
+> for the steal, `vehicle_finale.escorts` = who was at the delivery. Parsers reading
+> `obj_escort` will simply stop seeing the key.
+
+**`obj_vehicle` fields** (each key optional — only present when earned):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `escort` | object | Per-vehicle map: `{ [vehicle]: { time_s, distance } }` — seconds and game units accrued while alive, on the escorting team, within the escort radius (default 500u) of that vehicle **while it was moving**; accrual keeps accumulating across damage/repair/stop cycles. |
+| `damage` | object | `{ damage, hits }` — damage dealt to escort vehicles (`COLLECT_VEHICLE_DAMAGE` only) |
+| `repairs` | number | Vehicle repairs completed (`COLLECT_VEHICLE_DAMAGE` only) |
 
 **`stance_stats_seconds` fields:**
 
@@ -158,7 +175,7 @@ Ordered array of all events that occurred during the round. Every entry has:
 | `round_id` | number | Round number (injected at save time) |
 | `unixtime` | number | Wall-clock timestamp in **milliseconds** when the event was recorded. |
 | `leveltime` | number | Server level time (ms) when the event was recorded. Raw as emitted — see the pause note below. |
-| `group` | string | `"player"` or `"server"` |
+| `group` | string | `"player"`, `"server"` or `"vehicle"` |
 | `label` | string | Event type (see below) |
 | ...fields | — | Event-specific fields |
 
@@ -284,12 +301,76 @@ Ordered array of all events that occurred during the round. Every entry has:
 | `vsay_text` | Custom text for vsay commands with extra args (optional) |
 
 **Objective events** — `obj_planted`, `obj_defused`, `obj_destroyed`, `obj_repaired`,
-`obj_taken`, `obj_secured`, `obj_returned`, `obj_carrierkilled`
+`obj_taken`, `obj_repickup`, `obj_secured`, `obj_returned`
 
 | Field | Description |
 |-------|-------------|
 | `player` | GUID |
 | `objective` | Objective name from config |
+
+**`obj_carrierkilled`** — killed an enemy objective carrier (killer-credited; never
+emitted for selfkills, teamkills, or world deaths)
+
+| Field | Description |
+|-------|-------------|
+| `player` | Killer GUID |
+| `victim` | Carrier GUID |
+| `objective` | Objective the victim was carrying |
+| `weapon` | meansOfDeath |
+
+Attribution comes from the engine console lines directly (`Item:` line preceding the
+steal/return popup, `Objective_Destroyed: <clientNum>`, `Repair: <clientNum>`); announce-only
+destructions (e.g. command posts) are attributed via the most recent `et_Damage` hit on the
+entity. `obj_taken` is the initial steal from the stand; `obj_repickup` is a pickup of a
+dropped objective.
+
+**`obj_dropped`** — carrier lost the objective without securing/returning it: death,
+disconnect, or a manual `+dropobj`. Manual drops emit no console line at all — they are
+detected by polling the carrier's flag powerup (`PW_REDFLAG`/`PW_BLUEFLAG`) each frame.
+
+| Field | Description |
+|-------|-------------|
+| `player` | GUID of the carrier who dropped it |
+| `objective` | Objective name from config |
+| `pos` | `"x y z"` drop position (absent if unresolvable) |
+
+**Vehicle events** (`group: "vehicle"`) — emitted by entity-state tracking of escort
+vehicles (script_movers), enabled by `COLLECT_VEHICLE_STATS`. All carry a `vehicle` field
+(the entity's scriptName, e.g. `"tank"`).
+
+| Label | Extra fields | Description |
+|-------|--------------|-------------|
+| `vehicle_started` | `pos`, `escorts?` | Vehicle moved for the first time this round — `escorts` = who was there for the steal |
+| `vehicle_moving` | `pos`, `escorts?` | Vehicle resumed moving after a stop |
+| `vehicle_stopped` | `pos`, `segment_distance`, `escorts?` | No displacement for >1s; distance of the completed segment |
+| `vehicle_damaged` | `player?`, `pos` | Health hit 0 (disabled); `player` = last damager if attributable |
+| `vehicle_repaired` | `player?`, `pos` | Health restored; `player` = repairing engineer via `Repair:` line |
+| `vehicle_pos` | `pos`, `escorts?` | 1s position sample while moving (`COLLECT_VEHICLE_TELEMETRY` only) |
+| `vehicle_damage` | `player`, `damage` | Per-hit vehicle damage (`COLLECT_VEHICLE_DAMAGE` only) |
+| `vehicle_finale` | `pos`, `escorts?` | The map's escort announce fired (destination reached); `escorts` = owning-team players at the destination |
+| `vehicle_summary` | `total_distance`, `moving_time_s`, `damaged_count`, `repaired_count` | One per vehicle that entered play, at round end |
+
+`escorts` is the array of player GUIDs accruing escort credit at that moment (alive,
+escorting team, within the escort radius while the vehicle moves); omitted when empty.
+
+**`obj_damage`** — damage to a non-vehicle damageable objective (command post, destroyable
+walls); `COLLECT_VEHICLE_DAMAGE` only. Trucks never emit damage events — they are not
+damageable (`takedamage 0`), so the engine never fires the damage hook for them. Only hits
+that pass the engine's per-entity weapon-class gate arrive here, so volume is low.
+
+| Field | Description |
+|-------|-------------|
+| `player` | Attacker GUID |
+| `damage` | Damage amount |
+| `target` | Entity name (objective `track`, falling back to scriptName/classname) |
+
+**`carrier_pos`** — objective-carrier position sample (`COLLECT_VEHICLE_TELEMETRY` only)
+
+| Field | Description |
+|-------|-------------|
+| `player` | Carrier GUID |
+| `objective` | Objective being carried |
+| `pos` | `"x y z"`, sampled every 1s while carrying |
 
 **`obj_flag_captured`**
 
@@ -433,7 +514,8 @@ interface ObjStatEntry {
   timestamp_unix: UnixTime;
 }
 
-/** Carrier-kill entry — keyed by leveltime (as string). */
+/** Carrier-kill entry — keyed by leveltime (as string).
+ *  Recorded under the KILLER's guid; victim is the carrier they killed. */
 interface ObjCarrierKilledEntry {
   victim:         Guid;
   weapon:         number;
@@ -467,16 +549,35 @@ interface PlayerStat {
   obj_destroyed?:     ObjStatMap;
   obj_repaired?:      ObjStatMap;
   obj_taken?:         ObjStatMap;
+  obj_repickup?:      ObjStatMap;
+  obj_dropped?:       ObjStatMap;
   obj_secured?:       ObjStatMap;
   obj_returned?:      ObjStatMap;
-  obj_carrierkilled?: ObjCarrierKilledMap;
+  obj_carrierkilled?: ObjCarrierKilledMap;  // killer-credited (see entry type)
   obj_flagcaptured?:  ObjStatMap;
   obj_misc?:          ObjStatMap;
-  obj_escort?:        ObjStatMap;
 
   // COLLECT_SHOVE_STATS — objective field contains the other player's GUID
   shoves_given?:    ObjStatMap;
   shoves_received?: ObjStatMap;
+
+  // COLLECT_VEHICLE_STATS
+  obj_vehicle?: PlayerVehicleStats;
+
+  /** @deprecated removed in 2.7.0 — superseded by obj_vehicle.escort (per-vehicle
+   *  time/distance + finale). Never present in 2.7.0+ payloads. */
+  obj_escort?: ObjStatMap;
+}
+
+interface PlayerVehicleEscort {
+  time_s:   number;   // accrued while that vehicle moved
+  distance: number;
+}
+
+interface PlayerVehicleStats {
+  escort?:  Record<string, PlayerVehicleEscort>;  // keyed by vehicle scriptName
+  damage?:  { damage: number; hits: number };     // COLLECT_VEHICLE_DAMAGE only
+  repairs?: number;                               // COLLECT_VEHICLE_DAMAGE only
 }
 
 type PlayerStats = Record<Guid, PlayerStat>;
@@ -488,7 +589,7 @@ interface GamelogEventBase {
   round_id:  number;
   unixtime:  number;     // wall-clock ms since Unix epoch (raw; includes pause time)
   leveltime: LevelTime;  // server ms since map load (raw; paused time removed in ingest)
-  group:     "player" | "server";
+  group:     "player" | "server" | "vehicle";
   label:     string;
 }
 
@@ -604,7 +705,7 @@ interface MessageEvent extends GamelogEventBase {
 }
 
 type ObjectiveLabel = "obj_planted" | "obj_defused" | "obj_destroyed" | "obj_repaired"
-                    | "obj_taken"   | "obj_secured" | "obj_returned"  | "obj_carrierkilled";
+                    | "obj_taken"   | "obj_repickup" | "obj_secured" | "obj_returned";
 
 interface ObjectiveEvent extends GamelogEventBase {
   group:     "player";
@@ -612,6 +713,70 @@ interface ObjectiveEvent extends GamelogEventBase {
   player:    Guid;
   objective: string;
 }
+
+// Killed an enemy objective carrier — killer-credited
+interface ObjCarrierKilledEvent extends GamelogEventBase {
+  group:     "player";
+  label:     "obj_carrierkilled";
+  player:    Guid;    // killer
+  victim:    Guid;    // carrier
+  objective: string;
+  weapon:    number;
+}
+
+interface ObjDroppedEvent extends GamelogEventBase {
+  group:     "player";
+  label:     "obj_dropped";
+  player:    Guid;
+  objective: string;
+  pos:       Position | null;
+}
+
+interface CarrierPosEvent extends GamelogEventBase {  // COLLECT_VEHICLE_TELEMETRY
+  group:     "player";
+  label:     "carrier_pos";
+  player:    Guid;
+  objective: string;
+  pos:       Position;
+}
+
+// ─── vehicle events (COLLECT_VEHICLE_STATS) ────────────────────────────────
+
+interface VehicleEventBase extends GamelogEventBase {
+  group:   "vehicle";
+  vehicle: string;  // entity scriptName, e.g. "tank"
+}
+
+// escorts: GUIDs accruing escort credit at that moment; omitted when empty
+interface VehicleStartedEvent  extends VehicleEventBase { label: "vehicle_started";  pos: Position; escorts?: Guid[]; }
+interface VehicleMovingEvent   extends VehicleEventBase { label: "vehicle_moving";   pos: Position; escorts?: Guid[]; }
+interface VehicleStoppedEvent  extends VehicleEventBase { label: "vehicle_stopped";  pos: Position; segment_distance: number; escorts?: Guid[]; }
+interface VehicleDamagedEvent  extends VehicleEventBase { label: "vehicle_damaged";  pos: Position; player?: Guid; }
+interface VehicleRepairedEvent extends VehicleEventBase { label: "vehicle_repaired"; pos: Position; player?: Guid; }
+interface VehiclePosEvent      extends VehicleEventBase { label: "vehicle_pos";      pos: Position; escorts?: Guid[]; }  // COLLECT_VEHICLE_TELEMETRY
+interface VehicleDamageEvent   extends VehicleEventBase { label: "vehicle_damage";   player: Guid; damage: number; }  // COLLECT_VEHICLE_DAMAGE
+interface VehicleFinaleEvent   extends VehicleEventBase { label: "vehicle_finale";   pos: Position; escorts?: Guid[]; }
+
+// COLLECT_VEHICLE_DAMAGE: damage to non-vehicle damageable objectives (CP, walls)
+interface ObjDamageEvent extends GamelogEventBase {
+  group:  "player";
+  label:  "obj_damage";
+  player: Guid;
+  damage: number;
+  target: string;  // objective track name, falling back to scriptName/classname
+}
+interface VehicleSummaryEvent  extends VehicleEventBase {
+  label:          "vehicle_summary";
+  total_distance: number;
+  moving_time_s:  number;
+  damaged_count:  number;
+  repaired_count: number;
+}
+
+type VehicleEvent =
+  | VehicleStartedEvent | VehicleMovingEvent | VehicleStoppedEvent
+  | VehicleDamagedEvent | VehicleRepairedEvent | VehiclePosEvent
+  | VehicleDamageEvent | VehicleFinaleEvent | VehicleSummaryEvent;
 
 interface FlagCapturedEvent extends GamelogEventBase {
   group:  "player";
@@ -662,8 +827,9 @@ interface UnpauseEvent    extends GamelogEventBase { group: "server"; label: "un
 type GamelogEvent =
   | SpawnEvent | KillEvent | SuicideEvent | TeamkillEvent | DamageEvent
   | ReviveEvent | ClassChangeEvent | MessageEvent
-  | ObjectiveEvent | FlagCapturedEvent | PickupEvent | ShoveEvent
-  | WeaponFireEvent
+  | ObjectiveEvent | ObjCarrierKilledEvent | ObjDroppedEvent | ObjDamageEvent
+  | FlagCapturedEvent | PickupEvent | ShoveEvent
+  | WeaponFireEvent | CarrierPosEvent | VehicleEvent
   | RoundStartEvent | RoundEndEvent | PauseEvent | UnpauseEvent;
 
 // ─── metadata ──────────────────────────────────────────────────────────────
@@ -757,6 +923,9 @@ The match-ID endpoint is called as `GET {API_URL_MATCHID}/{server_ip}/{server_po
 | `COLLECT_SHOVE_STATS` | `true` | Shove tracking in `player_stats` and `gamelog` |
 | `COLLECT_MOVEMENT_STATS` | `true` | Distance travelled and speed in `player_stats` |
 | `COLLECT_STANCE_STATS` | `true` | Stance-time breakdown in `player_stats` |
+| `COLLECT_VEHICLE_STATS` | `true` | Entity-state escort vehicle tracking: per-player escort credit (`player_stats.obj_vehicle.escort`) and `vehicle_*` timeline events in `gamelog`. Active only on maps with an `escort` config section — its entry names (or `script_name` keys) pin the vehicle script_movers; maps without one have no vehicle and are skipped entirely. |
+| `COLLECT_VEHICLE_TELEMETRY` | `false` | 1-second position samples for moving vehicles (`vehicle_pos`) and objective carriers (`carrier_pos`). Higher volume — enable when route replay is wanted. |
+| `COLLECT_VEHICLE_DAMAGE` | `false` | Per-player damage tracking for damageable objectives: `vehicle_damage` events + `player_stats.obj_vehicle.damage` / `.repairs` for vehicles, and `obj_damage` events for constructibles (command posts, destroyable walls). Trucks are not damageable and never emit these. |
 
 ### [OUTPUT]
 
@@ -842,6 +1011,9 @@ silently ignored and the defaults above apply.
 | `STATS_API_SHOVESTATS` | `COLLECT_SHOVE_STATS` |
 | `STATS_API_MOVEMENTSTATS` | `COLLECT_MOVEMENT_STATS` |
 | `STATS_API_STANCESTATS` | `COLLECT_STANCE_STATS` |
+| `STATS_API_VEHICLESTATS` | `COLLECT_VEHICLE_STATS` |
+| `STATS_API_VEHICLE_TELEMETRY` | `COLLECT_VEHICLE_TELEMETRY` |
+| `STATS_API_VEHICLE_DAMAGE` | `COLLECT_VEHICLE_DAMAGE` |
 | `STATS_API_WEAPON_FIRE` | `COLLECT_WEAPON_FIRE` |
 | `STATS_API_DUMPJSON` | `DUMP_STATS_DATA` |
 | `STATS_SUBMIT` | `SUBMIT_TO_API` |
@@ -894,7 +1066,8 @@ Each map is declared under `[maps.<mapname>]`. Supported sub-sections:
 | `buildables.<name>` | `enabled = true` | Marks a common buildable as present on this map |
 | `flags.<name>` | `flag_pattern`, `flag_coordinates` | Checkpoint / flag capture attribution |
 | `misc.<name>` | `misc_pattern`, `misc_coordinates` | Coordinate-based misc objective |
-| `escort.<name>` | `escort_pattern`, `escort_coordinates` | Coordinate-based vehicle escort event |
+| `escort.<name>` | `escort_pattern`, `escort_coordinates` | Escort finale detection: when the announce matching `escort_pattern` fires, a `vehicle_finale` event is emitted listing the owning-team players within the escort radius of `escort_coordinates` (falling back to the vehicle's position) |
+| `escort.<name>` | `script_name`, `team`, `radius` | Entity-state vehicle tracking (the presence of an `escort` section enables it for the map). The vehicle script_mover is pinned by `script_name`, or by `<name>` itself when omitted (`escort.tank` → scriptName `tank`). Optional: escorting `team` (defaults to `"allies"` — attackers own escort objectives on every map in rotation; set `"axis"` for the rare inverted map) and escort `radius` (default 500 units) |
 
 ---
 
@@ -1011,6 +1184,12 @@ Both must be available to the ETLegacy Lua runtime (present in `lualibs/`):
 luascripts/
 ├── stats.lua                   ← entry point + configuration
 ├── config.toml                 ← map patterns only
+├── test/                       ← dev tooling, never loaded by stats.lua
+│   ├── entdump.lua             on-server diagnostic: dumps mover/checkpoint/constructible
+│   │                           entities to <fs_homepath>/legacy/entdump.log (load via lua_modules)
+│   ├── et_stub.lua             offline `et` API stub for the tests below
+│   ├── vehicle_test.lua        offline unit test:  lua5.4 luascripts/test/vehicle_test.lua
+│   └── replay.lua              offline regression: lua5.4 luascripts/test/replay.lua <console.log>
 └── stats/
     ├── util/
     │   ├── log.lua             timestamped file logger (info / debug levels)
@@ -1022,6 +1201,7 @@ luascripts/
     ├── gamelog.lua             in-memory event buffer
     ├── events.lua              et_Obituary, et_Damage, et_ClientCommand
     ├── objectives.lua          et_Print pattern matching, buildables, flags, shoves
+    ├── vehicle.lua             entity-state escort vehicle tracking (auto-detect, escort credit, timeline)
     ├── gather.lua              gather features: auto_rename, auto_sort, auto_start, auto_scores
     ├── api.lua                 match-ID fetch, version check
     ├── scores.lua              match score tracking (gather + ng modes)

--- a/luascripts/stats.lua
+++ b/luascripts/stats.lua
@@ -29,8 +29,8 @@ local COLLECT_MOVEMENT_STATS    = true
 local COLLECT_STANCE_STATS      = true   -- prone / crouch / sprint time, etc.
 local COLLECT_GAMELOG           = true   -- in-round event timeline (kills, damage, chat, objectives, etc.)
 local COLLECT_VEHICLE_STATS     = true   -- escort vehicle tracking: per-player escort credit + timeline events
-local COLLECT_VEHICLE_TELEMETRY = false  -- 1s position samples for vehicle + objective carriers (higher volume)
-local COLLECT_VEHICLE_DAMAGE    = false  -- per-player vehicle damage/repair tally events
+local COLLECT_VEHICLE_TELEMETRY = true   -- 1s position samples for vehicle + objective carriers (~200 events/round)
+local COLLECT_VEHICLE_DAMAGE    = true   -- per-player vehicle/objective damage + repair tally events
 local COLLECT_WEAPON_FIRE       = false  -- log every weapon shot (et_WeaponFire + et_FixedMGFire)
                                          -- WARNING: very high volume -- not recommended for normal use.
 

--- a/luascripts/stats.lua
+++ b/luascripts/stats.lua
@@ -1,6 +1,6 @@
 --[[
     stats.lua  — root module for ETLegacy game stats collection
-    Version: 2.6.0
+    Version: 2.7.0
 
     All user-facing settings live in the CONFIGURATION block below.
     config.toml is kept only for map-specific patterns and common buildables.
@@ -28,6 +28,9 @@ local COLLECT_SHOVE_STATS       = true
 local COLLECT_MOVEMENT_STATS    = true
 local COLLECT_STANCE_STATS      = true   -- prone / crouch / sprint time, etc.
 local COLLECT_GAMELOG           = true   -- in-round event timeline (kills, damage, chat, objectives, etc.)
+local COLLECT_VEHICLE_STATS     = true   -- escort vehicle tracking: per-player escort credit + timeline events
+local COLLECT_VEHICLE_TELEMETRY = false  -- 1s position samples for vehicle + objective carriers (higher volume)
+local COLLECT_VEHICLE_DAMAGE    = false  -- per-player vehicle damage/repair tally events
 local COLLECT_WEAPON_FIRE       = false  -- log every weapon shot (et_WeaponFire + et_FixedMGFire)
                                          -- WARNING: very high volume -- not recommended for normal use.
 
@@ -73,7 +76,7 @@ local SAVE_STATS_DELAY          = 3000   -- ms after intermission before SaveSta
 
 -- [MODULE]
 local MODNAME                   = "stats"
-local VERSION                   = "2.6.0"
+local VERSION                   = "2.7.0"
 
 -- [ENV OVERRIDES]
 -- Any setting above can be overridden by an environment variable of the same
@@ -98,6 +101,9 @@ COLLECT_OBJ_STATS               = env_bool("STATS_API_OBJSTATS",        COLLECT_
 COLLECT_SHOVE_STATS             = env_bool("STATS_API_SHOVESTATS",      COLLECT_SHOVE_STATS)
 COLLECT_MOVEMENT_STATS          = env_bool("STATS_API_MOVEMENTSTATS",   COLLECT_MOVEMENT_STATS)
 COLLECT_STANCE_STATS            = env_bool("STATS_API_STANCESTATS",     COLLECT_STANCE_STATS)
+COLLECT_VEHICLE_STATS           = env_bool("STATS_API_VEHICLESTATS",    COLLECT_VEHICLE_STATS)
+COLLECT_VEHICLE_TELEMETRY       = env_bool("STATS_API_VEHICLE_TELEMETRY", COLLECT_VEHICLE_TELEMETRY)
+COLLECT_VEHICLE_DAMAGE          = env_bool("STATS_API_VEHICLE_DAMAGE",  COLLECT_VEHICLE_DAMAGE)
 COLLECT_WEAPON_FIRE             = env_bool("STATS_API_WEAPON_FIRE",     COLLECT_WEAPON_FIRE)
 DUMP_STATS_DATA                 = env_bool("STATS_API_DUMPJSON",        DUMP_STATS_DATA)
 SUBMIT_TO_API                   = env_bool("STATS_SUBMIT",              SUBMIT_TO_API)
@@ -144,6 +150,7 @@ local movement                  = gs_require("movement")
 local gamelog                   = gs_require("gamelog")
 local events                    = gs_require("events")
 local objectives                = gs_require("objectives")
+local vehicle                   = gs_require("vehicle")
 local gather                    = gs_require("gather")
 local api                       = gs_require("api")
 local stats                     = gs_require("stats")
@@ -188,6 +195,9 @@ local function build_cfg()
         collect_movement_stats  = COLLECT_MOVEMENT_STATS,
         collect_stance_stats    = COLLECT_STANCE_STATS,
         collect_gamelog         = COLLECT_GAMELOG,
+        collect_vehicle_stats   = COLLECT_VEHICLE_STATS,
+        collect_vehicle_telemetry = COLLECT_VEHICLE_TELEMETRY,
+        collect_vehicle_damage  = COLLECT_VEHICLE_DAMAGE,
         collect_weapon_fire     = COLLECT_WEAPON_FIRE,
         dump_stats_data         = DUMP_STATS_DATA,
         submit_to_api           = SUBMIT_TO_API,
@@ -261,6 +271,9 @@ local function initialize_map_config()
 
     local map_config = map_configs[mapname]
     objectives.init_map(map_config, common_buildables)
+    if COLLECT_VEHICLE_STATS then
+        vehicle.init_map(map_config)
+    end
 
     if log_mod then
         local round = tonumber(et.trap_Cvar_Get("g_currentRound")) == 0 and 1 or 2
@@ -343,21 +356,24 @@ function et_InitGame()
     players.init(log_mod, maxClients)
     movement.init(log_mod, maxClients)
     gamelog.init(COLLECT_GAMELOG)
-    events.init(cfg, log_mod, players, gamelog, objectives)
-    objectives.init(cfg, log_mod, players, gamelog)
+    vehicle.init(cfg, log_mod, players, gamelog)
+    events.init(cfg, log_mod, players, gamelog, objectives, COLLECT_VEHICLE_STATS and vehicle or nil)
+    objectives.init(cfg, log_mod, players, gamelog, COLLECT_VEHICLE_STATS and vehicle or nil)
     scores.init(cfg, log_mod, http, gamestate)
     ng_scores.init(cfg, log_mod, scores, http, gather)
     gather.init(cfg, log_mod, http, api, scores)
     api.init(cfg, log_mod, http, gather, VERSION)
     api.set_server_info(server_ip, server_port)
     stats.init(cfg, log_mod, http, api,
-               movement, objectives, events, gamelog, players, VERSION, scores)
+               movement, objectives, events, gamelog, players, VERSION, scores,
+               COLLECT_VEHICLE_STATS and vehicle or nil)
     gamestate.init(cfg, log_mod, {
         players    = players,
         movement   = movement,
         gamelog    = gamelog,
         events     = events,
         objectives = objectives,
+        vehicle    = COLLECT_VEHICLE_STATS and vehicle or nil,
         gather     = gather,
         api        = api,
         stats      = stats,
@@ -380,6 +396,8 @@ function et_InitGame()
         log_mod.debug(string.format("  collect_movement    : %s", bool(COLLECT_MOVEMENT_STATS)))
         log_mod.debug(string.format("  collect_stance      : %s", bool(COLLECT_STANCE_STATS)))
         log_mod.debug(string.format("  collect_weapon_fire : %s", bool(COLLECT_WEAPON_FIRE)))
+        log_mod.debug(string.format("  collect_vehicle     : %s  telemetry=%s damage=%s",
+            bool(COLLECT_VEHICLE_STATS), bool(COLLECT_VEHICLE_TELEMETRY), bool(COLLECT_VEHICLE_DAMAGE)))
         log_mod.debug(string.format("  auto_rename         : %s", bool(AUTO_RENAME)))
         log_mod.debug(string.format("  auto_sort           : %s", bool(AUTO_SORT)))
         log_mod.debug(string.format("  auto_start          : %s", bool(AUTO_START)))
@@ -472,14 +490,23 @@ function et_RunFrame(frame_level_time)
 
     -- Pause markers: emit pause/unpause gamelog events on CS_SERVERTOGGLES transitions
     -- while a round is live. Ingest uses the pair to subtract paused time from the timeline.
-    if COLLECT_GAMELOG and current_gs == et.GS_PLAYING then
-        local paused = server_is_paused()
+    local is_playing = current_gs == et.GS_PLAYING
+    local paused     = is_playing and server_is_paused() or false
+    if COLLECT_GAMELOG and is_playing then
         if paused ~= _was_paused then
             if paused then gamelog.pause_start() else gamelog.pause_end() end
             _was_paused = paused
         end
     elseif _was_paused then
         _was_paused = false
+    end
+
+    if COLLECT_VEHICLE_STATS then
+        vehicle.tick(frame_level_time, paused, is_playing)
+    end
+    -- carrier upkeep: manual-drop (+dropobj) detection + carrier telemetry
+    if (COLLECT_OBJ_STATS or COLLECT_GAMELOG) and is_playing and not paused then
+        objectives.tick(frame_level_time)
     end
 
     if current_gs == et.GS_PLAYING and gamestate.round_start_time == 0 then
@@ -518,9 +545,11 @@ end
 
 function et_InitGame_Restart()
     log_mod.buffer_start()
+    -- reset first: gamestate.reset() clears objectives (incl. its map config),
+    -- so the map re-init must come after it
+    gamestate.reset(server_ip, server_port)
     initialize_map_config()
     events.parse_reinf_times()
-    gamestate.reset(server_ip, server_port)
     gamelog.round_start()
     gamestate.round_start_time = et.trap_Milliseconds()
     gamestate.round_start_unix = os.time()
@@ -542,6 +571,9 @@ function et_ClientBegin(clientNum)
 end
 
 function et_ClientDisconnect(clientNum)
+    if COLLECT_OBJ_STATS then
+        objectives.handle_disconnect(clientNum)
+    end
     players.on_disconnect(clientNum, movement)
     if AUTO_RENAME or AUTO_START then
         gather.on_disconnect(clientNum)

--- a/luascripts/stats/config.lua
+++ b/luascripts/stats/config.lua
@@ -98,6 +98,10 @@ local function process_map(map_name, map_data)
             entry.escort[utils.normalize(e_name)] = {
                 escort_pattern     = utils.normalize(e_data.escort_pattern or ""),
                 escort_coordinates = e_data.escort_coordinates,
+                -- vehicle.lua overrides: pin the script_mover, owning team, radius
+                script_name        = e_data.script_name,
+                team               = e_data.team and utils.normalize(e_data.team) or nil,
+                radius             = tonumber(e_data.radius),
             }
         end
     end

--- a/luascripts/stats/events.lua
+++ b/luascripts/stats/events.lua
@@ -15,6 +15,9 @@ local objectives_ref
 local vehicle_ref
 
 local MAX_CLIENT_SLOTS = 64  -- entity numbers below this are always clients
+local ET_CONSTRUCTIBLE = 33  -- entityType_t: engineer build/destroy objectives
+                             -- (CP, breach walls, barriers). Not exposed as an
+                             -- et.* constant, so matched numerically.
 
 local _collect_gamelog      = true
 local _collect_weapon_fire  = false
@@ -198,22 +201,39 @@ end
 
 
 function events.on_damage(target, attacker, damage, damage_flags, mod)
-    -- Non-client target: escort vehicle or other damageable map entity
-    -- (constructible, command post, ...). et_Damage fires for these too, and
-    -- only for hits that pass the engine's weapon-class gate for the entity.
+    -- Non-client target: escort vehicle or a damageable objective. et_Damage
+    -- fires for every damageable entity — corpse gibs (ET_CORPSE),
+    -- func_explosive breakables and decorative props (chairs, windows,
+    -- paintings) all reach here — so past the vehicle hand-off we keep only
+    -- ET_CONSTRUCTIBLE (command posts, breach walls, barriers) and drop the rest.
     if type(target) == "number" and target >= MAX_CLIENT_SLOTS then
         local now = et.trap_Milliseconds()
-        local handled = vehicle_ref and vehicle_ref.on_damage(target, attacker, damage, now)
-        if not handled and objectives_ref and objectives_ref.on_entity_damage then
-            objectives_ref.on_entity_damage(target, attacker, now)
+        if vehicle_ref and vehicle_ref.on_damage(target, attacker, damage, now) then
+            return
+        end
 
-            if _collect_obj_damage and _collect_gamelog and gamelog_ref then
-                local entry = players_ref.guids[attacker]
-                if entry and entry.guid and entry.guid ~= "WORLD" then
+        if (tonumber(et.gentity_get(target, "s.eType")) or -1) ~= ET_CONSTRUCTIBLE then
+            return
+        end
+
+        if objectives_ref and objectives_ref.on_entity_damage then
+            objectives_ref.on_entity_damage(target, attacker, now)
+        end
+
+        if _collect_obj_damage and _collect_gamelog and gamelog_ref then
+            local entry = players_ref.guids[attacker]
+            if entry and entry.guid and entry.guid ~= "WORLD" then
+                -- Clamp to remaining health: the engine passes raw damage and
+                -- subtracts health only after this hook, so an airstrike
+                -- overkilling a near-dead objective would otherwise report its
+                -- full amount instead of the fraction that mattered.
+                local hp  = tonumber(et.gentity_get(target, "health")) or 0
+                local eff = math.min(damage or 0, math.max(0, hp))
+                if eff > 0 then
                     local name = et.gentity_get(target, "track")
                     if not name or name == "" then name = et.gentity_get(target, "scriptName") end
                     if not name or name == "" then name = et.gentity_get(target, "classname") end
-                    gamelog_ref.obj_damage(entry.guid, damage or 0, name or "unknown")
+                    gamelog_ref.obj_damage(entry.guid, eff, name or "unknown")
                 end
             end
         end

--- a/luascripts/stats/events.lua
+++ b/luascripts/stats/events.lua
@@ -12,9 +12,13 @@ local log
 local players_ref
 local gamelog_ref
 local objectives_ref
+local vehicle_ref
+
+local MAX_CLIENT_SLOTS = 64  -- entity numbers below this are always clients
 
 local _collect_gamelog      = true
 local _collect_weapon_fire  = false
+local _collect_obj_damage   = false
 local _maxClients           = 64
 
 local CON_CONNECTED = 2
@@ -45,14 +49,16 @@ local _aReinfOffset     = {}  -- populated by parse_reinf_times()
 local _level_time       = 0   -- updated from et_RunFrame via events.set_level_time()
 
 
-function events.init(cfg, log_ref, players_module, gamelog_module, objectives_module)
+function events.init(cfg, log_ref, players_module, gamelog_module, objectives_module, vehicle_module)
     log            = log_ref
     players_ref    = players_module
     gamelog_ref    = gamelog_module
     objectives_ref = objectives_module
+    vehicle_ref    = vehicle_module
 
     _collect_gamelog     = cfg.collect_gamelog
     _collect_weapon_fire = cfg.collect_weapon_fire or false
+    _collect_obj_damage  = cfg.collect_vehicle_damage or false
     _maxClients          = cfg.maxClients or 64
 end
 
@@ -152,21 +158,32 @@ function events.on_obituary(target, attacker, mod)
                      and attacker_guid ~= "WORLD"
 
     if _collect_gamelog and gamelog_ref then
+        -- The engine drops carried objectives (G_DropItems) before this hook
+        -- runs, so the victim's flag powerup is already cleared — restore the
+        -- carrying state from the objectives carrier table.
+        local function fix_carrier_stance(snap)
+            if snap and objectives_ref and objectives_ref.is_carrier
+            and objectives_ref.is_carrier(target) then
+                snap.is_carrying_obj = true
+            end
+            return snap
+        end
+
         if is_suicide then
-            local victim_snap  = players_ref.get_snapshot(target)
+            local victim_snap  = fix_carrier_stance(players_ref.get_snapshot(target))
             local victim_reinf = victim_entry and calc_reinf_time(victim_entry.team) or 0
             local victim_team  = victim_entry and victim_entry.team
             gamelog_ref.suicide(victim_snap, mod, victim_reinf, victim_team)
 
         elseif is_teamkill then
             local killer_snap  = players_ref.get_snapshot(attacker)
-            local victim_snap  = players_ref.get_snapshot(target)
+            local victim_snap  = fix_carrier_stance(players_ref.get_snapshot(target))
             local victim_reinf = victim_entry and calc_reinf_time(victim_entry.team) or 0
             gamelog_ref.teamkill(killer_snap, victim_snap, mod, victim_reinf)
 
         else
             local killer_snap  = players_ref.get_snapshot(attacker)
-            local victim_snap  = players_ref.get_snapshot(target)
+            local victim_snap  = fix_carrier_stance(players_ref.get_snapshot(target))
             local alive        = players_ref.count_alive()
             local killer_reinf = attacker_entry and calc_reinf_time(attacker_entry.team) or 0
             local victim_reinf = victim_entry   and calc_reinf_time(victim_entry.team)   or 0
@@ -181,6 +198,28 @@ end
 
 
 function events.on_damage(target, attacker, damage, damage_flags, mod)
+    -- Non-client target: escort vehicle or other damageable map entity
+    -- (constructible, command post, ...). et_Damage fires for these too, and
+    -- only for hits that pass the engine's weapon-class gate for the entity.
+    if type(target) == "number" and target >= MAX_CLIENT_SLOTS then
+        local now = et.trap_Milliseconds()
+        local handled = vehicle_ref and vehicle_ref.on_damage(target, attacker, damage, now)
+        if not handled and objectives_ref and objectives_ref.on_entity_damage then
+            objectives_ref.on_entity_damage(target, attacker, now)
+
+            if _collect_obj_damage and _collect_gamelog and gamelog_ref then
+                local entry = players_ref.guids[attacker]
+                if entry and entry.guid and entry.guid ~= "WORLD" then
+                    local name = et.gentity_get(target, "track")
+                    if not name or name == "" then name = et.gentity_get(target, "scriptName") end
+                    if not name or name == "" then name = et.gentity_get(target, "classname") end
+                    gamelog_ref.obj_damage(entry.guid, damage or 0, name or "unknown")
+                end
+            end
+        end
+        return
+    end
+
     if not _collect_gamelog or not gamelog_ref then return end
 
     local hit_region     = get_hit_region(attacker)

--- a/luascripts/stats/gamelog.lua
+++ b/luascripts/stats/gamelog.lua
@@ -170,6 +170,54 @@ function gamelog.obj_flag_captured(guid, flag_name)
     })
 end
 
+-- Killed an enemy objective carrier — credited to the killer
+function gamelog.obj_carrier_killed(killer_guid, victim_guid, obj_name, weapon)
+    gamelog.record("obj_carrierkilled", "player", {
+        player    = killer_guid,
+        victim    = victim_guid,
+        objective = obj_name,
+        weapon    = weapon,
+    })
+end
+
+function gamelog.obj_dropped(guid, obj_name, pos)
+    gamelog.record("obj_dropped", "player", {
+        player    = guid,
+        objective = obj_name,
+        pos       = pos,
+    })
+end
+
+-- Damage to a non-vehicle damageable objective (command post, destroyable
+-- walls). Only hits passing the engine's weapon-class gate arrive here.
+function gamelog.obj_damage(guid, damage, target_name)
+    gamelog.record("obj_damage", "player", {
+        player = guid,
+        damage = damage,
+        target = target_name,
+    })
+end
+
+-- Vehicle timeline / telemetry event (label e.g. "vehicle_started",
+-- "vehicle_stopped", "vehicle_damaged", "vehicle_repaired", "vehicle_pos",
+-- "vehicle_damage", "vehicle_summary")
+function gamelog.vehicle_event(label, vehicle_name, fields)
+    local ev = { vehicle = vehicle_name }
+    if fields then
+        for k, v in pairs(fields) do ev[k] = v end
+    end
+    gamelog.record(label, "vehicle", ev)
+end
+
+-- Objective-carrier position telemetry sample
+function gamelog.carrier_pos(guid, obj_name, pos)
+    gamelog.record("carrier_pos", "player", {
+        player    = guid,
+        objective = obj_name,
+        pos       = pos,
+    })
+end
+
 -- Pickup from console log
 function gamelog.pickup(player_snap, item, owner_snap)
     gamelog.record("pickup", "player", {

--- a/luascripts/stats/gamestate.lua
+++ b/luascripts/stats/gamestate.lua
@@ -14,6 +14,7 @@ local movement_ref
 local gamelog_ref
 local events_ref
 local objectives_ref
+local vehicle_ref
 local gather_ref
 local api_ref
 local stats_ref
@@ -41,6 +42,7 @@ function gamestate.init(cfg, log_ref, all_modules)
     gamelog_ref    = all_modules.gamelog
     events_ref     = all_modules.events
     objectives_ref = all_modules.objectives
+    vehicle_ref    = all_modules.vehicle
     gather_ref     = all_modules.gather
     api_ref        = all_modules.api
     stats_ref      = all_modules.stats
@@ -110,6 +112,8 @@ function gamestate.handle_change(new_gs, server_ip, server_port, frame_time)
         gamestate.round_end_time = et.trap_Milliseconds()
         gamestate.round_end_unix = os.time()
 
+        -- vehicle summary must land in the gamelog before the round_end marker
+        if vehicle_ref then vehicle_ref.round_end() end
         if gamelog_ref then gamelog_ref.round_end() end
 
         if gather_ref then

--- a/luascripts/stats/objectives.lua
+++ b/luascripts/stats/objectives.lua
@@ -2,6 +2,13 @@
     stats/objectives.lua
     Handles et_Print for all objective pattern matching, buildable tracking,
     flag/item pickups, shove tracking, and objective-carrier death attribution.
+
+    Attribution relies on the current ET:Legacy console output:
+      - "Item: N team_CTF_*flag" precedes the matching "legacy popup:" line
+        (same frame) for both steals AND returns — N is the acting client.
+      - "Objective_Destroyed: N <track>" — N is the planting client.
+      - "Repair: N" — N is the repairing client.
+    Older ET:Legacy builds that omitted these lines are not supported.
 --]]
 
 local objectives = {}
@@ -10,6 +17,7 @@ local utils = require("luascripts/stats/util/utils")
 local log
 local players_ref
 local gamelog_ref
+local vehicle_ref
 
 local _collect_objstats     = true
 local _collect_shovestats   = true
@@ -24,8 +32,7 @@ objectives.objstats         = {}
 local objective_carriers    = { players = {}, ids = {} }
 
 -- objective_states[obj_name] = {
---   last_popup, last_announce, last_action, timestamp,
---   carrier_id, planter_guid
+--   last_announce, last_action, timestamp, carrier_id, dropped
 -- }
 local objective_states      = {}
 
@@ -35,6 +42,23 @@ local ANNOUNCE_BUFFER       = 5
 local REPAIR_BUFFER_MS      = 2000
 local MAX_OBJ_DISTANCE      = 500  -- game units
 local pending_pickup        = nil
+
+-- Last "Item: N team_CTF_*flag" line — consumed by the popup that follows it.
+local pending_flag_touch    = nil  -- { clientNum, timestamp }
+local FLAG_TOUCH_WINDOW_MS  = 150
+
+-- Recent damage to non-client entities (from et_Damage), used to attribute
+-- destruction of buildables that emit no Objective_Destroyed line (e.g.
+-- command posts destroyed by direct fire/satchel).
+local recent_entity_damage  = {}   -- newest first: { entnum, attacker, timestamp }
+local ENTITY_DAMAGE_BUFFER  = 8
+local ENTITY_DAMAGE_WINDOW_MS = 1000
+local DESTROY_DEDUP_MS      = 1500
+
+-- Carrier position telemetry cadence (gated by collect_vehicle_telemetry)
+local _collect_telemetry    = false
+local CARRIER_POS_INTERVAL_MS = 1000
+local _last_carrier_pos_ms  = 0
 
 -- Active map config
 local _map_config           = nil
@@ -102,6 +126,8 @@ local function record_obj_stat(guid, event_type, objective, killer_info)
             obj_planted       = {},
             obj_destroyed     = {},
             obj_taken         = {},
+            obj_repickup      = {},
+            obj_dropped       = {},
             obj_returned      = {},
             obj_secured       = {},
             obj_repaired      = {},
@@ -109,7 +135,6 @@ local function record_obj_stat(guid, event_type, objective, killer_info)
             obj_carrierkilled = {},
             obj_flagcaptured  = {},
             obj_misc          = {},
-            obj_escort        = {},
             shoves_given      = {},
             shoves_received   = {},
         }
@@ -146,7 +171,6 @@ end
 local function update_objective_state(obj_name, action, guid, normalized_text)
     if not objective_states[obj_name] then
         objective_states[obj_name] = {
-            last_popup    = "",
             last_announce = "",
             last_action   = "",
             timestamp     = 0,
@@ -159,10 +183,6 @@ local function update_objective_state(obj_name, action, guid, normalized_text)
 
     if normalized_text then
         objective_states[obj_name].last_announce = normalized_text
-    end
-
-    if guid and action == "planted" then
-        objective_states[obj_name].planter_guid = guid.guid or guid
     end
 
     return ts
@@ -232,46 +252,33 @@ local function get_flag_coordinates()
 end
 
 
-local function get_active_covert_ops()
-    local COVERT_OPS = 4
-    local result = {}
-    for clientNum, entry in pairs(players_ref.guids) do
-        if entry.team == et.TEAM_AXIS or entry.team == et.TEAM_ALLIES then
-            local pt = tonumber(et.gentity_get(clientNum, "sess.playerType"))
-            if pt == COVERT_OPS then
-                table.insert(result, clientNum)
-            end
-        end
-    end
-    return result
-end
-
-
-local function handle_destroyer_attribution(obj_name)
-    local state = objective_states[obj_name]
-    if state and state.planter_guid then
-        return state.planter_guid, true
-    end
-
-    local coverts = get_active_covert_ops()
-    if #coverts == 1 then
-        local entry = players_ref.guids[coverts[1]]
-        return entry and entry.guid, true
-    end
-
-    return nil, false
-end
-
-
-local function handle_buildable_destruction(obj_name, normalized_text)
-    local destroyer_guid, found = handle_destroyer_attribution(obj_name)
-    if found and destroyer_guid then
-        record_obj_stat(destroyer_guid, "obj_destroyed", obj_name)
+local function emit_destroyed(guid, obj_name, normalized_text)
+    if guid then
+        record_obj_stat(guid, "obj_destroyed", obj_name)
         if _collect_gamelog and gamelog_ref then
-            gamelog_ref.objective("obj_destroyed", destroyer_guid, obj_name)
+            gamelog_ref.objective("obj_destroyed", guid, obj_name)
         end
     end
     update_objective_state(obj_name, "destroyed", nil, normalized_text)
+end
+
+
+-- Announce-only destructions (no Objective_Destroyed line, e.g. command posts):
+-- attribute to whoever last damaged a non-client entity — the destruction
+-- announce fires in the same frame as the killing blow.
+local function handle_buildable_destruction(obj_name, normalized_text)
+    local current_time = et.trap_Milliseconds()
+    local guid
+    for _, dmg in ipairs(recent_entity_damage) do
+        if (current_time - dmg.timestamp) <= ENTITY_DAMAGE_WINDOW_MS then
+            local entry = players_ref.guids[dmg.attacker]
+            if entry and entry.guid and entry.guid ~= "WORLD" then
+                guid = entry.guid
+                break
+            end
+        end
+    end
+    emit_destroyed(guid, obj_name, normalized_text)
 end
 
 
@@ -372,14 +379,16 @@ local function handle_dynamite_event(text, event_type, action_name)
 end
 
 
-function objectives.init(cfg, log_ref, players_module, gamelog_module)
+function objectives.init(cfg, log_ref, players_module, gamelog_module, vehicle_module)
     log                 = log_ref
     players_ref         = players_module
     gamelog_ref         = gamelog_module
+    vehicle_ref         = vehicle_module
 
     _collect_objstats   = cfg.collect_obj_stats
     _collect_shovestats = cfg.collect_shove_stats
     _collect_gamelog    = cfg.collect_gamelog
+    _collect_telemetry  = cfg.collect_vehicle_telemetry or false
     _maxClients         = cfg.maxClients or 64
 end
 
@@ -393,12 +402,11 @@ function objectives.init_map(map_config, common_buildables)
     if map_config.objectives then
         for _, obj in ipairs(map_config.objectives) do
             objective_states[obj.name] = {
-                last_popup    = "",
                 last_announce = "",
                 last_action   = "",
                 carrier_id    = nil,
+                dropped       = false,
                 timestamp     = 0,
-                planter_guid  = nil,
             }
         end
     end
@@ -406,7 +414,6 @@ function objectives.init_map(map_config, common_buildables)
     if map_config.buildables then
         for obj_name, _ in pairs(map_config.buildables) do
             objective_states[obj_name] = objective_states[obj_name] or {
-                last_popup    = "",
                 last_announce = "",
                 last_action   = "",
                 timestamp     = 0,
@@ -493,21 +500,46 @@ function objectives.handle_print(text)
     if not _map_config then return end
     if not _collect_objstats then return end
 
-    -- Objective_Destroyed: <id> <text>
+    -- Objective_Destroyed: <id> <track>
+    -- id is the planting client; track is the same text the Dynamite_Plant
+    -- line carried, so plant_pattern resolves the objective name.
     if string.find(text, "Objective_Destroyed:", 1, true) then
         local id_str, obj_text = text:match("^Objective_Destroyed: (%d+) (.+)$")
         if id_str and obj_text then
             local normalized = utils.normalize(obj_text:match("^%s*(.-)%s*$") or obj_text)
-            if _map_config.buildables then
+            local entry      = players_ref.guids[tonumber(id_str)]
+            local guid       = entry and entry.guid
+
+            local resolved
+            if _common_buildables and _map_config.buildables then
+                for obj_name, common_cfg in pairs(_common_buildables) do
+                    if _map_config.buildables[obj_name]
+                    and type(common_cfg.patterns) == "table" and common_cfg.patterns.plant then
+                        for _, p in ipairs(common_cfg.patterns.plant) do
+                            if string.find(normalized, utils.normalize(p)) then
+                                resolved = obj_name
+                                break
+                            end
+                        end
+                    end
+                    if resolved then break end
+                end
+            end
+            if not resolved and _map_config.buildables then
                 for obj_name, obj_cfg in pairs(_map_config.buildables) do
-                    if type(obj_cfg) == "table"
-                    and obj_cfg.destruct_pattern and obj_cfg.destruct_pattern ~= ""
-                    and string.find(normalized, utils.normalize(obj_cfg.destruct_pattern)) then
-                        handle_buildable_destruction(obj_name, normalized)
-                        break
+                    if type(obj_cfg) == "table" then
+                        if (obj_cfg.plant_pattern and obj_cfg.plant_pattern ~= ""
+                            and string.find(normalized, utils.normalize(obj_cfg.plant_pattern)))
+                        or (obj_cfg.destruct_pattern and obj_cfg.destruct_pattern ~= ""
+                            and string.find(normalized, utils.normalize(obj_cfg.destruct_pattern))) then
+                            resolved = obj_name
+                            break
+                        end
                     end
                 end
             end
+
+            emit_destroyed(guid, resolved or normalized, normalized)
         end
     end
 
@@ -548,7 +580,12 @@ function objectives.handle_print(text)
                     if matched_construct then
                         update_objective_state(obj_name, "constructed", nil, normalized)
                     elseif matched_destruct then
-                        handle_buildable_destruction(obj_name, normalized)
+                        local state = objective_states[obj_name]
+                        if not (state
+                            and state.last_action == "destroyed"
+                            and (current_time - state.timestamp) < DESTROY_DEDUP_MS) then
+                            handle_buildable_destruction(obj_name, normalized)
+                        end
                     end
                 end
             end
@@ -567,7 +604,7 @@ function objectives.handle_print(text)
                         local state = objective_states[obj_name]
                         if not (state
                             and state.last_action == "destroyed"
-                            and (current_time - state.timestamp) < 1000) then
+                            and (current_time - state.timestamp) < DESTROY_DEDUP_MS) then
                             handle_buildable_destruction(obj_name, normalized)
                         end
                     end
@@ -648,57 +685,85 @@ function objectives.handle_print(text)
             end
         end
 
-        -- Escort objectives
-        if _map_config.escort then
+        -- Escort finale announces → vehicle module (marks finale involvement
+        -- on the per-vehicle escort credit instead of a one-shot proximity stat)
+        if _map_config.escort and vehicle_ref and vehicle_ref.on_escort_finale then
             for escort_name, escort_data in pairs(_map_config.escort) do
-                if escort_data.escort_pattern and escort_data.escort_coordinates
+                if escort_data.escort_pattern and escort_data.escort_pattern ~= ""
                 and string.find(normalized, utils.normalize(escort_data.escort_pattern)) then
-                    local nearest = find_nearest_players(escort_data.escort_coordinates, et.TEAM_ALLIES)
-                    for _, cnum in ipairs(nearest) do
-                        local guid = players_ref.guids[cnum] and players_ref.guids[cnum].guid
-                        if guid then
-                            record_obj_stat(guid, "obj_escort", escort_name)
-                        end
-                    end
+                    vehicle_ref.on_escort_finale(escort_name, escort_data.escort_coordinates)
                     break
                 end
             end
         end
     end
 
-    -- legacy popup: popup state for objective steal / return
+    -- legacy popup: objective steal / return
     if string.find(text, "legacy popup:", 1, true) then
-        local normalized = utils.normalize(utils.strip_colors(text))
+        local normalized = utils.normalize(utils.strip_colors(text)):gsub('"', '')
+
+        local touch_id
+        if pending_flag_touch
+        and (current_time - pending_flag_touch.timestamp) <= FLAG_TOUCH_WINDOW_MS then
+            touch_id = pending_flag_touch.clientNum
+        end
 
         if _map_config.objectives then
             for _, obj in ipairs(_map_config.objectives) do
                 if obj.steal_pattern and obj.steal_pattern ~= ""
-                and string.find(normalized, utils.normalize(obj.steal_pattern)) then
-                    if not objective_states[obj.name] then
-                        objective_states[obj.name] = { last_popup = "", last_announce = "",
-                            last_action = "", timestamp = 0 }
+                and string.find(normalized, (utils.normalize(obj.steal_pattern):gsub('"', ''))) then
+                    local state = objective_states[obj.name]
+                    if not state then
+                        state = { last_announce = "", last_action = "", timestamp = 0 }
+                        objective_states[obj.name] = state
                     end
-                    objective_states[obj.name].last_popup = normalized
-                    objective_states[obj.name].timestamp  = current_time
+
+                    local entry = touch_id and players_ref.guids[touch_id]
+                    if entry and entry.guid and entry.guid ~= "WORLD" then
+                        local event = state.dropped and "obj_repickup" or "obj_taken"
+                        record_obj_stat(entry.guid, event, obj.name)
+                        if _collect_gamelog and gamelog_ref then
+                            gamelog_ref.objective(event, entry.guid, obj.name)
+                        end
+
+                        objective_carriers.players[touch_id] = obj.name
+                        state.carrier_id = touch_id
+                        local found = false
+                        for _, v in ipairs(objective_carriers.ids) do
+                            if v == touch_id then found = true; break end
+                        end
+                        if not found then
+                            table.insert(objective_carriers.ids, touch_id)
+                        end
+                    end
+
+                    state.dropped     = false
+                    state.last_action = "taken"
+                    state.timestamp   = current_time
+                    pending_flag_touch = nil
                     break
 
                 elseif obj.return_pattern and obj.return_pattern ~= ""
-                and string.find(normalized, utils.normalize(obj.return_pattern)) then
-                    local state = objective_states[obj.name]
-                    local returner_guid = state and state.carrier_id
-                        and players_ref.guids[state.carrier_id]
-                        and players_ref.guids[state.carrier_id].guid
-                        or "WORLD"
+                and string.find(normalized, (utils.normalize(obj.return_pattern):gsub('"', ''))) then
+                    local entry = touch_id and players_ref.guids[touch_id]
+                    local returner_guid = entry and entry.guid or "WORLD"
 
                     record_obj_stat(returner_guid, "obj_returned", obj.name)
                     if _collect_gamelog and gamelog_ref then
                         gamelog_ref.objective("obj_returned", returner_guid, obj.name)
                     end
 
-                    if state and state.carrier_id then
-                        objective_carriers.players[state.carrier_id] = nil
-                        state.carrier_id = nil
+                    local state = objective_states[obj.name]
+                    if state then
+                        if state.carrier_id then
+                            objective_carriers.players[state.carrier_id] = nil
+                            state.carrier_id = nil
+                        end
+                        state.dropped     = false
+                        state.last_action = "returned"
+                        state.timestamp   = current_time
                     end
+                    pending_flag_touch = nil
                     break
                 end
             end
@@ -718,6 +783,11 @@ function objectives.handle_print(text)
         if id_str then
             local id    = tonumber(id_str)
             local entry = players_ref.guids[id]
+
+            if vehicle_ref then
+                vehicle_ref.on_repair(id, current_time)
+            end
+
             if entry then
                 local guid         = entry.guid
                 local objective_name = "Unknown Repair"
@@ -753,37 +823,12 @@ function objectives.handle_print(text)
     end
 
     -- Item: <clientNum> team_CTF_redflag / team_CTF_blueflag
+    -- Precedes the steal/return popup; stash the toucher for it to consume.
     if string.find(text, "Item:", 1, true)
     and (string.find(text, "team_CTF_redflag", 1, true) or string.find(text, "team_CTF_blueflag", 1, true)) then
         local id = tonumber(text:match("Item: (%d+)"))
-        if id and _map_config.objectives then
-            for _, obj in ipairs(_map_config.objectives) do
-                local state = objective_states[obj.name]
-                if state and state.last_popup and state.last_popup ~= ""
-                and (current_time - state.timestamp) < 1000 then
-                    local norm_popup = utils.normalize(utils.strip_colors(state.last_popup))
-                    if obj.steal_pattern ~= "" and string.find(norm_popup, utils.normalize(obj.steal_pattern)) then
-                        local entry = players_ref.guids[id]
-                        if entry then
-                            record_obj_stat(entry.guid, "obj_taken", obj.name)
-                            if _collect_gamelog and gamelog_ref then
-                                gamelog_ref.objective("obj_taken", entry.guid, obj.name)
-                            end
-
-                            objective_carriers.players[id] = obj.name
-                            state.carrier_id = id
-                            local found = false
-                            for _, v in ipairs(objective_carriers.ids) do
-                                if v == id then found = true; break end
-                            end
-                            if not found then
-                                table.insert(objective_carriers.ids, id)
-                            end
-                        end
-                        break
-                    end
-                end
-            end
+        if id then
+            pending_flag_touch = { clientNum = id, timestamp = current_time }
         end
     end
 
@@ -831,31 +876,150 @@ function objectives.handle_print(text)
 end
 
 
+
 function objectives.handle_carrier_death(target, attacker, mod, gamelog_module)
     for obj_name, state in pairs(objective_states) do
         if state.carrier_id == target then
             local victim_entry  = players_ref.guids[target]
             local killer_entry  = players_ref.guids[attacker]
+            local victim_guid   = victim_entry and victim_entry.guid or "WORLD"
 
-            local victim_guid = victim_entry  and victim_entry.guid  or "WORLD"
-            local killer_guid = killer_entry  and killer_entry.guid  or "WORLD"
+            local gl = gamelog_module or gamelog_ref
 
-            record_obj_stat(victim_guid, "obj_carrierkilled", obj_name, {
-                guid      = killer_guid,
-                weapon    = mod,
-                objective = obj_name,
-            })
+            if killer_entry and killer_entry.guid and killer_entry.guid ~= "WORLD"
+            and attacker ~= target
+            and victim_entry and killer_entry.team ~= victim_entry.team then
+                record_obj_stat(killer_entry.guid, "obj_carrierkilled", obj_name, {
+                    guid      = victim_guid,
+                    weapon    = mod,
+                    objective = obj_name,
+                })
+                if _collect_gamelog and gl then
+                    gl.obj_carrier_killed(killer_entry.guid, victim_guid, obj_name, mod)
+                end
+            end
 
-            if _collect_gamelog and (gamelog_module or gamelog_ref) then
-                local gl = gamelog_module or gamelog_ref
-                gl.objective("obj_carrierkilled", victim_guid, obj_name)
+            record_obj_stat(victim_guid, "obj_dropped", obj_name)
+            if _collect_gamelog and gl then
+                local pos = et.gentity_get(target, "r.currentOrigin")
+                gl.obj_dropped(victim_guid, obj_name, utils.fmt_pos(pos))
             end
 
             objective_carriers.players[target] = nil
-            state.carrier_id = nil
-            state.last_action = "killed"
+            state.carrier_id  = nil
+            state.dropped     = true
+            state.last_action = "dropped"
+            state.timestamp   = et.trap_Milliseconds()
         end
     end
+end
+
+
+-- Carrier disconnects also drop the objective.
+function objectives.handle_disconnect(clientNum)
+    for obj_name, state in pairs(objective_states) do
+        if state.carrier_id == clientNum then
+            local entry = players_ref.guids[clientNum]
+            local guid  = entry and entry.guid or "WORLD"
+
+            record_obj_stat(guid, "obj_dropped", obj_name)
+            if _collect_gamelog and gamelog_ref then
+                local pos = et.gentity_get(clientNum, "r.currentOrigin")
+                gamelog_ref.obj_dropped(guid, obj_name, utils.fmt_pos(pos))
+            end
+
+            objective_carriers.players[clientNum] = nil
+            state.carrier_id  = nil
+            state.dropped     = true
+            state.last_action = "dropped"
+            state.timestamp   = et.trap_Milliseconds()
+        end
+    end
+end
+
+
+-- Damage to non-client entities, routed from events.on_damage.
+-- Buffered for announce-only destruction attribution (command posts etc.).
+function objectives.on_entity_damage(target, attacker, timestamp)
+    table.insert(recent_entity_damage, 1,
+        { entnum = target, attacker = attacker, timestamp = timestamp })
+    if #recent_entity_damage > ENTITY_DAMAGE_BUFFER then
+        table.remove(recent_entity_damage)
+    end
+end
+
+
+local PW_REDFLAG  = 5
+local PW_BLUEFLAG = 6
+
+-- Manual drops (+dropobj) are completely silent on the console —
+-- Cmd_DropObjective_f emits no log line or popup. Detect them by polling the
+-- carrier's flag powerup: a tracked carrier who is alive but no longer holds
+-- PW_REDFLAG/PW_BLUEFLAG has dropped the objective. Death/return/secure paths
+-- clear the carrier table synchronously (same server frame as their console
+-- lines), so they never reach this check.
+local function check_manual_drops()
+    for clientNum, obj_name in pairs(objective_carriers.players) do
+        local health = tonumber(et.gentity_get(clientNum, "health")) or 0
+        if health > 0 then
+            local red  = tonumber(et.gentity_get(clientNum, "ps.powerups", PW_REDFLAG))  or 0
+            local blue = tonumber(et.gentity_get(clientNum, "ps.powerups", PW_BLUEFLAG)) or 0
+            if red == 0 and blue == 0 then
+                local entry = players_ref.guids[clientNum]
+                local guid  = entry and entry.guid or "WORLD"
+
+                record_obj_stat(guid, "obj_dropped", obj_name)
+                if _collect_gamelog and gamelog_ref then
+                    local pos = et.gentity_get(clientNum, "r.currentOrigin")
+                    gamelog_ref.obj_dropped(guid, obj_name, utils.fmt_pos(pos))
+                end
+
+                objective_carriers.players[clientNum] = nil
+                local state = objective_states[obj_name]
+                if state then
+                    state.carrier_id  = nil
+                    state.dropped     = true
+                    state.last_action = "dropped"
+                    state.timestamp   = et.trap_Milliseconds()
+                end
+            end
+        end
+    end
+end
+
+
+-- Per-frame carrier upkeep: manual-drop detection (always) and carrier
+-- position telemetry (collect_vehicle_telemetry, 1s cadence).
+function objectives.tick(now)
+    if next(objective_carriers.players) == nil then return end
+
+    check_manual_drops()
+
+    if not _collect_telemetry or not _collect_gamelog or not gamelog_ref then return end
+    if (now ~= nil and _last_carrier_pos_ms ~= 0
+        and (now - _last_carrier_pos_ms) < CARRIER_POS_INTERVAL_MS) then
+        return
+    end
+    _last_carrier_pos_ms = now or 0
+
+    for clientNum, obj_name in pairs(objective_carriers.players) do
+        local entry = players_ref.guids[clientNum]
+        if entry and entry.guid and entry.guid ~= "WORLD" then
+            local pos = et.gentity_get(clientNum, "r.currentOrigin")
+            if pos then
+                gamelog_ref.carrier_pos(entry.guid, obj_name, utils.fmt_pos(pos))
+            end
+        end
+    end
+end
+
+
+-- True while clientNum is a tracked objective carrier. Used by events.lua to
+-- correct death snapshots: the engine drops carried items (G_DropItems)
+-- before the obituary hook fires, so the flag powerup is already gone when
+-- the victim snapshot is taken.
+function objectives.is_carrier(clientNum)
+    return objective_carriers.players[clientNum] ~= nil
 end
 
 
@@ -876,6 +1040,9 @@ function objectives.reset()
     objective_states     = {}
     recent_announcements = {}
     pending_pickup       = nil
+    pending_flag_touch   = nil
+    recent_entity_damage = {}
+    _last_carrier_pos_ms = 0
     _map_config          = nil
     _common_buildables   = nil
 end

--- a/luascripts/stats/stats.lua
+++ b/luascripts/stats/stats.lua
@@ -16,6 +16,7 @@ local http_ref
 local api_ref
 local movement_ref
 local objectives_ref
+local vehicle_ref
 local events_ref
 local gamelog_ref
 local players_ref
@@ -45,7 +46,7 @@ local PERS_SCORE        = 0
 function stats.init(cfg, log_ref, http_module, api_module,
                     movement_module, objectives_module,
                     events_module, gamelog_module, players_module, version_str,
-                    scores_module)
+                    scores_module, vehicle_module)
     log            = log_ref
     http_ref       = http_module
     api_ref        = api_module
@@ -55,6 +56,7 @@ function stats.init(cfg, log_ref, http_module, api_module,
     gamelog_ref    = gamelog_module
     players_ref    = players_module
     scores_ref     = scores_module
+    vehicle_ref    = vehicle_module
 
     _api_token          = cfg.api_token             or ""
     _url_submit         = cfg.api_url_submit        or ""
@@ -116,12 +118,16 @@ function stats.store(maxClients)
                 end
             end
 
-            if dwWeaponMask ~= 0 then
+            local team = et.gentity_get(i, "sess.sessionTeam")
+
+            -- Record every team player, weapon interactions or not — objective
+            -- runners (escort, courier) can finish a round without a single
+            -- tracked shot and must still get a player_stats row.
+            if dwWeaponMask ~= 0 or team == 1 or team == 2 then
                 local userinfo      = et.trap_GetUserinfo(i)
                 local guid          = string.upper(et.Info_ValueForKey(userinfo, "cl_guid"))
                 local name          = et.gentity_get(i, "pers.netname")
                 local rounds        = et.gentity_get(i, "sess.rounds")
-                local team          = et.gentity_get(i, "sess.sessionTeam")
 
                 local dmg_given     = et.gentity_get(i, "sess.damage_given")
                 local dmg_recv      = et.gentity_get(i, "sess.damage_received")
@@ -200,6 +206,7 @@ function stats.save(round_start_time, round_end_time, round_start_unix, round_en
     local metadata = scores_ref and scores_ref.get_metadata(round_info) or nil
 
     local player_stats = {}
+    local vehicle_stats = vehicle_ref and vehicle_ref.get_stats() or nil
 
     for guid, row_str in pairs(_weapon_stats) do
         local parts = {}
@@ -274,6 +281,10 @@ function stats.save(round_start_time, round_end_time, round_start_unix, round_en
                     end
                 end
             end
+        end
+
+        if vehicle_stats and vehicle_stats[guid] then
+            player_stats[guid].obj_vehicle = vehicle_stats[guid]
         end
 
     end

--- a/luascripts/stats/vehicle.lua
+++ b/luascripts/stats/vehicle.lua
@@ -1,0 +1,464 @@
+--[[
+    stats/vehicle.lua
+    Entity-state driven escort vehicle tracking.
+
+    Instead of matching per-map announce strings, escort vehicles (tank,
+    truck - script_mover entities with a scriptName) are found at map
+    init and each is polled every tick:
+      - origin delta   → moving / stopped / distance travelled
+      - health <= 0    → damaged (disabled)
+      - health restore → repaired
+    Maps can have several escort vehicles in sequence (goldrush: tank then
+    truck), so every candidate runs its own state machine; a candidate enters
+    the timeline the first time it moves or takes damage.
+
+    Per-player escort credit (time + distance) accrues while a vehicle is
+    actually moving and the player is alive, on the owning team and within
+    ESCORT_RADIUS of it.
+
+    Damage attribution comes from et_Damage (fires for script_movers with a
+    scriptName — target is the vehicle entnum). Repair attribution comes from
+    the "Repair: <clientNum>" console line forwarded by objectives.lua.
+--]]
+
+local vehicle = {}
+local utils = require("luascripts/stats/util/utils")
+
+local log
+local players_ref
+local gamelog_ref
+
+local _collect_telemetry    = false
+local _collect_damage       = false
+
+local POLL_INTERVAL_MS      = 250
+local TELEMETRY_INTERVAL_MS = 1000
+local STOP_GRACE_MS         = 1000   -- moving → stopped after this long without displacement
+local INIT_GRACE_MS         = 2000   -- after a fresh poll clock: resync only, no events/credit.
+                                     -- Covers mid-round VM reloads where the engine restores
+                                     -- mover positions/health a few frames after lua init.
+local MOVE_EPSILON          = 1      -- units per poll below this = not moving
+local TELEPORT_LIMIT        = 512    -- origin jump larger than this per poll = relink/teleport, no credit
+local REPAIR_WINDOW_MS      = 3000   -- Repair: N line must arrive within this of a health restore
+local DAMAGE_WINDOW_MS      = 3000   -- et_Damage must precede the disable transition within this
+local DEFAULT_ESCORT_RADIUS = 500    -- game units, override via config escort.<name>.radius
+
+local ENT_FIRST             = 64
+local ENT_LAST              = 1021
+
+-- candidates[entnum] = per-vehicle state machine:
+-- { script_name, origin, health, disabled, started, is_moving,
+--   last_move_ms, last_telemetry_ms, segment_distance, total_distance,
+--   moving_time_ms, damaged_count, repaired_count, last_damager }
+local candidates            = {}
+
+local owner_team            = nil    -- et.TEAM_ALLIES / et.TEAM_AXIS
+local escort_radius         = DEFAULT_ESCORT_RADIUS
+local last_poll_ms          = 0
+local grace_until_ms        = 0      -- resync-only until this time after a fresh clock
+local pending_repair        = nil    -- { clientNum, ms } from "Repair: N"
+
+-- escort_credit[guid][vehicle_script_name] = { time_ms, distance, finale }
+local escort_credit         = {}
+-- damage_tally[guid] = { damage, hits }   repair_tally[guid] = count
+local damage_tally          = {}
+local repair_tally          = {}
+
+
+local function guid_of(clientNum)
+    local entry = players_ref and players_ref.guids[clientNum]
+    return entry and entry.guid ~= "WORLD" and entry.guid or nil
+end
+
+
+local function emit(label, cand, fields)
+    if gamelog_ref then
+        gamelog_ref.vehicle_event(label, cand and cand.script_name or nil, fields)
+    end
+    if log then
+        log.debug(string.format("Vehicle: %s (%s)", label, cand and cand.script_name or "?"))
+    end
+end
+
+
+function vehicle.init(cfg, log_ref, players_module, gamelog_module)
+    log         = log_ref
+    players_ref = players_module
+    gamelog_ref = gamelog_module
+
+    _collect_telemetry = cfg.collect_vehicle_telemetry or false
+    _collect_damage    = cfg.collect_vehicle_damage or false
+end
+
+
+-- Scan for script_mover candidates. Vehicle tracking requires the map to
+-- have an escort config section — maps without one (radar, adlernest, …)
+-- have no escort vehicle, but do carry damageable script_movers (cabinets,
+-- radios) that must not masquerade as vehicles. Escort entries narrow the
+-- scan: an entry's explicit `script_name` — or, failing that, its own
+-- section name (escort.tank → scriptName "tank") — pins the matching
+-- movers; the unfiltered mover set is only kept when nothing matches.
+function vehicle.init_map(map_config)
+    vehicle.reset()
+
+    if not (map_config and map_config.escort and next(map_config.escort)) then
+        if log then
+            log.write("Vehicle tracking off — no escort config for this map")
+        end
+        return
+    end
+
+    local pinned = {}
+    do
+        for e_name, e_cfg in pairs(map_config.escort) do
+            if e_cfg.script_name and e_cfg.script_name ~= "" then
+                pinned[utils.normalize(e_cfg.script_name)] = true
+            else
+                pinned[utils.normalize(e_name)] = true
+            end
+            if e_cfg.team == "axis" then owner_team = et.TEAM_AXIS end
+            if tonumber(e_cfg.radius) then escort_radius = tonumber(e_cfg.radius) end
+        end
+    end
+    -- Escorts are an attacker objective and attackers are allies on every
+    -- map in rotation; `team = "axis"` in the escort config overrides.
+    owner_team = owner_team or et.TEAM_ALLIES
+
+    local all, matched = {}, {}
+    for entnum = ENT_FIRST, ENT_LAST do
+        if et.gentity_get(entnum, "classname") == "script_mover" then
+            local sname = et.gentity_get(entnum, "scriptName")
+            if sname and sname ~= "" then
+                local origin = et.gentity_get(entnum, "r.currentOrigin")
+                local cand = {
+                    script_name       = sname,
+                    origin            = origin and { origin[1], origin[2], origin[3] } or nil,
+                    health            = tonumber(et.gentity_get(entnum, "health")) or 0,
+                    disabled          = false,
+                    started           = false,
+                    is_moving         = false,
+                    last_move_ms      = 0,
+                    last_telemetry_ms = 0,
+                    segment_distance  = 0,
+                    total_distance    = 0,
+                    moving_time_ms    = 0,
+                    damaged_count     = 0,
+                    repaired_count    = 0,
+                    last_damager      = nil,
+                }
+                all[entnum] = cand
+                if pinned[utils.normalize(sname)] then
+                    matched[entnum] = cand
+                end
+            end
+        end
+    end
+
+    candidates = next(matched) and matched or all
+    if log then
+        for entnum, cand in pairs(candidates) do
+            log.write(string.format("Vehicle candidate: ent %d scriptName=%s%s",
+                entnum, cand.script_name, matched[entnum] and " (pinned)" or ""))
+        end
+    end
+end
+
+
+local function escort_entry(guid, vehicle_name)
+    local per = escort_credit[guid]
+    if not per then
+        per = {}
+        escort_credit[guid] = per
+    end
+    local acc = per[vehicle_name]
+    if not acc then
+        acc = { time_ms = 0, distance = 0 }
+        per[vehicle_name] = acc
+    end
+    return acc
+end
+
+
+-- Returns the guids credited this tick so movement/telemetry events can
+-- carry the escorting players alongside the vehicle position.
+local function accrue_escort(cand, origin, displacement, dt_ms)
+    local escorts = {}
+    for clientNum, entry in pairs(players_ref.guids) do
+        if entry.team == owner_team and entry.guid and entry.guid ~= "WORLD" then
+            local health = tonumber(et.gentity_get(clientNum, "health")) or 0
+            local pos    = et.gentity_get(clientNum, "r.currentOrigin")
+            if health > 0 and pos and utils.distance3d_units(origin, pos) <= escort_radius then
+                local acc = escort_entry(entry.guid, cand.script_name)
+                acc.time_ms  = acc.time_ms + dt_ms
+                acc.distance = acc.distance + displacement
+                table.insert(escorts, entry.guid)
+            end
+        end
+    end
+    return escorts
+end
+
+
+local function poll_entity(entnum, cand, now, dt_ms)
+    local origin = et.gentity_get(entnum, "r.currentOrigin")
+    local health = tonumber(et.gentity_get(entnum, "health")) or 0
+
+    local displacement = 0
+    if origin and cand.origin then
+        displacement = utils.distance3d_units(cand.origin, origin)
+    end
+    if displacement >= TELEPORT_LIMIT then
+        displacement = 0  -- relink/teleport jump — no movement credit
+    end
+
+    local moved = displacement >= MOVE_EPSILON
+
+    -- movement transitions
+    if moved then
+        local escorts = accrue_escort(cand, origin, displacement, dt_ms)
+        if #escorts == 0 then escorts = nil end  -- omit empty arrays from the JSON
+        cand.last_escorts = escorts
+
+        if not cand.is_moving then
+            cand.is_moving = true
+            if not cand.started then
+                cand.started = true
+                emit("vehicle_started", cand, { pos = utils.fmt_pos(origin), escorts = escorts })
+            else
+                emit("vehicle_moving", cand, { pos = utils.fmt_pos(origin), escorts = escorts })
+            end
+        end
+        cand.last_move_ms     = now
+        cand.segment_distance = cand.segment_distance + displacement
+        cand.total_distance   = cand.total_distance + displacement
+        cand.moving_time_ms   = cand.moving_time_ms + dt_ms
+
+        if _collect_telemetry and (now - cand.last_telemetry_ms) >= TELEMETRY_INTERVAL_MS then
+            cand.last_telemetry_ms = now
+            emit("vehicle_pos", cand, { pos = utils.fmt_pos(origin), escorts = escorts })
+        end
+    elseif cand.is_moving and (now - cand.last_move_ms) >= STOP_GRACE_MS then
+        cand.is_moving = false
+        emit("vehicle_stopped", cand, {
+            pos              = utils.fmt_pos(origin),
+            segment_distance = math.floor(cand.segment_distance),
+            escorts          = cand.last_escorts,
+        })
+        cand.segment_distance = 0
+        cand.last_escorts     = nil
+    end
+
+    -- health transitions
+    if not cand.disabled and cand.health > 0 and health <= 0 then
+        cand.disabled      = true
+        cand.damaged_count = cand.damaged_count + 1
+        local damager_guid
+        if cand.last_damager and (now - cand.last_damager.ms) <= DAMAGE_WINDOW_MS then
+            damager_guid = guid_of(cand.last_damager.clientNum)
+        end
+        emit("vehicle_damaged", cand, { player = damager_guid, pos = utils.fmt_pos(origin) })
+    elseif cand.disabled and health > 0 then
+        cand.disabled       = false
+        cand.repaired_count = cand.repaired_count + 1
+        local repairer_guid
+        if pending_repair and (now - pending_repair.ms) <= REPAIR_WINDOW_MS then
+            repairer_guid = guid_of(pending_repair.clientNum)
+            if _collect_damage and repairer_guid then
+                repair_tally[repairer_guid] = (repair_tally[repairer_guid] or 0) + 1
+            end
+            pending_repair = nil
+        end
+        emit("vehicle_repaired", cand, { player = repairer_guid, pos = utils.fmt_pos(origin) })
+    end
+
+    cand.origin = origin and { origin[1], origin[2], origin[3] } or cand.origin
+    cand.health = health
+end
+
+
+-- Resync tracked origin/health to the live entity state without emitting
+-- anything. Used while the poll clock is in its grace window.
+local function resync_candidates()
+    for entnum, cand in pairs(candidates) do
+        local origin = et.gentity_get(entnum, "r.currentOrigin")
+        cand.origin = origin and { origin[1], origin[2], origin[3] } or cand.origin
+        cand.health = tonumber(et.gentity_get(entnum, "health")) or cand.health
+    end
+end
+
+
+-- Called from et_RunFrame. Skips accrual across pauses/non-play frames by
+-- restarting the poll clock instead of accumulating a large dt. A fresh
+-- clock opens a short grace window that only resyncs entity state — the
+-- engine may still be restoring mover positions/health (mid-round VM
+-- reload), and those restore jumps must not become events or credit.
+function vehicle.tick(now, paused, playing)
+    if not next(candidates) then return end
+
+    if paused or not playing then
+        last_poll_ms = 0
+        return
+    end
+
+    if last_poll_ms == 0 then
+        grace_until_ms = now + INIT_GRACE_MS
+    end
+
+    if now < grace_until_ms then
+        resync_candidates()
+        last_poll_ms = now
+        return
+    end
+
+    if (now - last_poll_ms) < POLL_INTERVAL_MS then return end
+    local dt_ms  = now - last_poll_ms
+    last_poll_ms = now
+
+    for entnum, cand in pairs(candidates) do
+        poll_entity(entnum, cand, now, dt_ms)
+    end
+end
+
+
+function vehicle.on_damage(target, attacker, damage, now)
+    local cand = candidates[target]
+    if not cand then return false end
+
+    cand.last_damager = { clientNum = attacker, ms = now }
+
+    if _collect_damage then
+        local guid = guid_of(attacker)
+        if guid then
+            local tally = damage_tally[guid]
+            if not tally then
+                tally = { damage = 0, hits = 0 }
+                damage_tally[guid] = tally
+            end
+            tally.damage = tally.damage + (damage or 0)
+            tally.hits   = tally.hits + 1
+            emit("vehicle_damage", cand, { player = guid, damage = damage or 0 })
+        end
+    end
+    return true
+end
+
+
+function vehicle.on_repair(clientNum, now)
+    for _, cand in pairs(candidates) do
+        if cand.disabled then
+            pending_repair = { clientNum = clientNum, ms = now }
+            return
+        end
+    end
+end
+
+
+-- Escort finale: the map's escort announce fired ("Bank Doors destroyed",
+-- "escaped with the Gold Crate", …). Emits a vehicle_finale timeline event
+-- listing the owning-team players at the destination — the "who delivered
+-- it" fact, complementing vehicle_started's "who stole it" escorts. The
+-- per-player stats stay pure cumulative time/distance. Forwarded by
+-- objectives.lua from the configured escort_pattern; coords come from
+-- escort_coordinates, falling back to the named vehicle's current position.
+function vehicle.on_escort_finale(escort_name, coords_str)
+    local wanted = utils.normalize(escort_name or "")
+    local vname, ref
+
+    for entnum, cand in pairs(candidates) do
+        if utils.normalize(cand.script_name) == wanted then
+            vname = cand.script_name
+            ref   = et.gentity_get(entnum, "r.currentOrigin")
+            break
+        end
+    end
+    vname = vname or escort_name
+
+    if coords_str then
+        local x, y, z = tostring(coords_str):match("([%-%.%d]+)%s+([%-%.%d]+)%s+([%-%.%d]+)")
+        if x then ref = { tonumber(x), tonumber(y), tonumber(z) } end
+    end
+    if not ref or not owner_team then return end
+
+    local escorts = {}
+    for clientNum, entry in pairs(players_ref.guids) do
+        if entry.team == owner_team and entry.guid and entry.guid ~= "WORLD" then
+            local health = tonumber(et.gentity_get(clientNum, "health")) or 0
+            local pos    = et.gentity_get(clientNum, "r.currentOrigin")
+            if health > 0 and pos and utils.distance3d_units(ref, pos) <= escort_radius then
+                table.insert(escorts, entry.guid)
+            end
+        end
+    end
+
+    if gamelog_ref then
+        gamelog_ref.vehicle_event("vehicle_finale", vname, {
+            pos     = utils.fmt_pos(ref),
+            escorts = #escorts > 0 and escorts or nil,
+        })
+    end
+end
+
+
+function vehicle.round_end()
+    for _, cand in pairs(candidates) do
+        if cand.started then
+            emit("vehicle_summary", cand, {
+                total_distance = math.floor(cand.total_distance),
+                moving_time_s  = math.floor(cand.moving_time_ms / 1000),
+                damaged_count  = cand.damaged_count,
+                repaired_count = cand.repaired_count,
+            })
+        end
+    end
+end
+
+
+-- Per-guid stats merged into player_stats at SaveStats time.
+-- { [guid] = { escort = { [vehicle] = {time_s, distance} },
+--              damage = {damage, hits}, repairs = n } }
+function vehicle.get_stats()
+    local out = {}
+    local function row(guid)
+        local r = out[guid]
+        if not r then r = {}; out[guid] = r end
+        return r
+    end
+
+    for guid, per in pairs(escort_credit) do
+        local escort = {}
+        for vname, acc in pairs(per) do
+            escort[vname] = {
+                time_s   = math.floor(acc.time_ms / 1000),
+                distance = math.floor(acc.distance),
+            }
+        end
+        row(guid).escort = escort
+    end
+    for guid, tally in pairs(damage_tally) do
+        row(guid).damage = { damage = tally.damage, hits = tally.hits }
+    end
+    for guid, count in pairs(repair_tally) do
+        row(guid).repairs = count
+    end
+    return out
+end
+
+
+function vehicle.is_vehicle(entnum)
+    return candidates[entnum] ~= nil
+end
+
+
+function vehicle.reset()
+    candidates     = {}
+    owner_team     = nil
+    escort_radius  = DEFAULT_ESCORT_RADIUS
+    last_poll_ms   = 0
+    grace_until_ms = 0
+    pending_repair = nil
+    escort_credit  = {}
+    damage_tally   = {}
+    repair_tally   = {}
+end
+
+return vehicle

--- a/luascripts/stats/vehicle.lua
+++ b/luascripts/stats/vehicle.lua
@@ -329,14 +329,22 @@ function vehicle.on_damage(target, attacker, damage, now)
     if _collect_damage then
         local guid = guid_of(attacker)
         if guid then
-            local tally = damage_tally[guid]
-            if not tally then
-                tally = { damage = 0, hits = 0 }
-                damage_tally[guid] = tally
+            -- Clamp to the vehicle's remaining health: the engine passes raw
+            -- damage and subtracts health only after the hook, so a panzer or
+            -- airstrike overkilling a near-dead tank would otherwise report its
+            -- full amount rather than the fraction that disabled it.
+            local hp  = tonumber(et.gentity_get(target, "health")) or 0
+            local eff = math.min(damage or 0, math.max(0, hp))
+            if eff > 0 then
+                local tally = damage_tally[guid]
+                if not tally then
+                    tally = { damage = 0, hits = 0 }
+                    damage_tally[guid] = tally
+                end
+                tally.damage = tally.damage + eff
+                tally.hits   = tally.hits + 1
+                emit("vehicle_damage", cand, { player = guid, damage = eff })
             end
-            tally.damage = tally.damage + (damage or 0)
-            tally.hits   = tally.hits + 1
-            emit("vehicle_damage", cand, { player = guid, damage = damage or 0 })
         end
     end
     return true


### PR DESCRIPTION
  - vehicle.lua: entity-state escort tracking via script_mover polling, per-player per-vehicle escort time/distance, timeline events (started/moving/stopped/damaged/repaired/finale/summary) with escort rosters, optional 1s telemetry and per-player damage/repair tallies (STATS_API_VEHICLE_TELEMETRY, STATS_API_VEHICLE_DAMAGE)
  - vehicle tracking gated per map by the escort config section; entry names pin script_movers; owning team defaults to allies
  - fix players with zero weapon interactions not getting player_stats rows
  - fix in-VM map_restart wiping the objectives map config (reset order)
  - death snapshots restore is_carrying_obj (engine drops carried items before the obituary hook)
  - offline regression tests (lua5.4 luascripts/test/) + entdump.lua on-server entity diagnostic