### PR TITLE
* Fixed carrier/vehicle telemetry timestamps: vehicle.tick, objective…

### DIFF
--- a/luascripts/README.md
+++ b/luascripts/README.md
@@ -307,7 +307,31 @@ Ordered array of all events that occurred during the round. Every entry has:
 |-------|-------------|
 | `player` | GUID |
 | `objective` | Objective name from config |
-| `pos` | `"x y z"` — `obj_taken` / `obj_repickup` (where the carry run started) and `obj_secured` (where it ended). Absent on the other objective labels, and on all of them in rounds recorded before 2.7.1. |
+| `pos` | `"x y z"` — the acting player's origin when the event fired. See the table below for the exceptions. |
+| `run` | Carry-run id, on the labels that bound a run (`obj_taken`, `obj_repickup`, `obj_secured`, `obj_returned`). See [Grouping samples into runs](#grouping-samples-into-runs) for what it means on each. 2.7.2+ |
+
+> **Changed in 2.7.2.** Before 2.7.2 only the carry cycle carried a position
+> (`obj_taken` / `obj_repickup` / `obj_secured`, plus `obj_dropped`); everything else had
+> none, which is why plants, defuses, destructions, repairs and flag captures could not be
+> drawn on a replay. No version gate is needed to consume this: an event either carries a
+> position or it does not, and older reports simply show fewer markers.
+
+Where each position comes from:
+
+| Label | `pos` is |
+|-------|----------|
+| `obj_taken`, `obj_repickup` | where the carry run started |
+| `obj_secured` | where it ended — the same reading as the run's final `carrier_pos` |
+| `obj_dropped` | where the objective was lost, likewise shared with the closing sample |
+| `obj_planted`, `obj_defused` | the engineer's origin, i.e. the charge |
+| `obj_repaired` | the engineer's origin |
+| `obj_returned` | the returner's origin — they had to reach the objective to return it, so this is where it was lying. A `WORLD` return (the objective timing out back to its stand after being dropped and left) has no actor and falls back to the position the carry ended at, which is the same spot |
+| `obj_destroyed` | **dynamite:** the position the charge was *planted* at, remembered from `obj_planted` — the destruction fires ~30s after the plant, by which time the planter is usually dead or respawned across the map. **Announce-only destructions** (command posts, satchel, direct fire): the destroyed entity's own origin, taken from the `et_Damage` record that attributed it. Never the attacker's position — a satchel has to be placed on the target, but a panzerfaust or tank shell can take a command post from across the map |
+
+`pos` is absent only when no trustworthy source existed: an origin reading that failed
+validation (see the `carrier_pos` section on closing points), or a brush entity reporting
+`0 0 0`. An absent `pos` is always a deliberate omission rather than a zero — the field is
+simply not present, and never a placeholder coordinate.
 
 **`obj_carrierkilled`** — killed an enemy objective carrier (killer-credited; never
 emitted for selfkills, teamkills, or world deaths)
@@ -318,6 +342,9 @@ emitted for selfkills, teamkills, or world deaths)
 | `victim` | Carrier GUID |
 | `objective` | Objective the victim was carrying |
 | `weapon` | meansOfDeath |
+| `pos` | Killer origin (follows `kill`'s `killer_pos`). 2.7.2+ |
+| `victim_pos` | Carrier origin — where the objective went down, and the same reading as the run's closing `carrier_pos`. This is the useful one for a replay. 2.7.2+ |
+| `run` | The **victim's** carry run that this kill ended. The event is credited to the killer but describes the victim's run. 2.7.2+ |
 
 Attribution comes from the engine console lines directly (`Item:` line preceding the
 steal/return popup, `Objective_Destroyed: <clientNum>`, `Repair: <clientNum>`); announce-only
@@ -375,6 +402,7 @@ landed. Trucks never emit these: they are not damageable (`takedamage 0`).
 | `player` | Carrier GUID |
 | `objective` | Objective being carried |
 | `pos` | `"x y z"` path vertex — see below |
+| `run` | Carry-run id — see [Grouping samples into runs](#grouping-samples-into-runs). 2.7.2+ |
 
 Carrier and vehicle positions are read every frame but emitted only where the path
 turns (`stats/util/pathgate.lua`), because these points are drawn as a polyline: a
@@ -383,23 +411,81 @@ carrier at `g_speed 320` covers ~400 units in a second. The emitted polyline sta
 within ~48 units of the real path (~64 for vehicles), with extra points at height
 changes, at direction reversals, on coming to a stop, and once a second while
 stationary. Spacing is therefore irregular — consume it by `leveltime`, never by
-assuming a fixed interval. Point count is independent of `sv_fps` (which ranges
-40–125 across the shipped configs) and lands at or below the previous 1s cadence:
-a 33s two-corner run with two holds costs ~30 events at every frame rate.
+assuming a fixed interval.
+
+**Carriers additionally have a 10 Hz spacing floor while they are moving** (2.7.2+,
+`move_gap_ms`). Corner vertices alone describe a route's shape but chord across it, so a
+strafe-jumped or circle-strafed approach measures shorter than it was; the floor puts
+samples ~32 units apart at `g_speed 320`, inside the corridor tolerance, so the polyline
+is the route rather than an approximation of it. The floor is gated on distance covered,
+not on frame count, so volume remains independent of `sv_fps` (which ranges 40–125 across
+the shipped configs) — verified at 49 points for the same ground at `sv_fps` 125, 50 and
+20. A carrier standing still never trips it and stays on the 1 Hz keepalive.
+
+Vehicles keep pure vertex gating: an escort truck runs 8+ minutes on a fixed spline, where
+a floor would cost thousands of points and buy no fidelity.
+
+Budget: the floor costs ~1.6x total gamelog events on the heaviest round in the reference
+set (`decay_sw` round 1, 212.6s of carry time — 423 `carrier_pos` before, ~2100 after).
+Expect roughly `10 x carry_seconds` samples per round.
+
+#### Grouping samples into runs
+
+From 2.7.2 every `carrier_pos` carries a `run`, a per-round id allocated on each pickup and
+shared with the events that bound that carry. **Group by `run` to partition a round's
+samples into carries.** Ids start at 1 each round, count in pickup order, and are shared
+across objectives.
+
+| Label | Relationship to `run` |
+|-------|-----------------------|
+| `obj_taken`, `obj_repickup` | opens the run |
+| `carrier_pos` | belongs to it |
+| `obj_secured`, `obj_dropped` | closes it |
+| `obj_carrierkilled` | closes it — credited to the killer, but the id is the **victim's** run |
+| `obj_returned` | names the run it **terminated**, which has normally already closed. An objective is returned while it lies on the ground, so the return follows an `obj_dropped` rather than ending a live carry: the id says this carry ended in a reset rather than in someone picking the objective back up. After a re-pickup it names the latest run, not the first. |
+
+This is not a convenience. `(player, objective)` does not identify a carry: on
+`karsiah_te2` round 1 of match `075fe912` a single player takes `north_documents` four
+separate times. Before 2.7.2 the only way to partition was to replay the surrounding
+events in array order, and a consumer that gets that state machine wrong fuses two
+disjoint carries into one and draws a segment across the map. Pre-2.7.2 reports still
+require that fallback.
 
 **`leveltime` is when the position was sampled, not when the event was emitted.** A
 corner vertex is only recognised once the entity has moved off the corridor, so it
 is emitted a few frames late (measured worst case ~150ms) and backdated to the frame
 it was actually sampled at. Coordinate and timestamp therefore always describe the
 same instant, at the cost of `carrier_pos` sometimes appearing in the array slightly
-after an event with a later `leveltime`. The `carrier_pos` series is itself strictly
-monotonic; ordering *between* streams is `event_index`, i.e. array order.
+after an event with a later `leveltime`. Within one run the samples are non-decreasing
+in `leveltime` and none exceeds the event that ends the run; across runs and across
+carriers the streams interleave, so ordering *between* them is `event_index`, i.e. array
+order. (This holds from 2.7.2 — see the clock note below for what pre-2.7.2 reports do.)
 
 Each carry run is closed out with a final `carrier_pos` at the exact position where
 it ended, emitted before the `obj_secured` / `obj_dropped` / `obj_carrierkilled` event
 that ends it, and nothing is emitted for that player afterwards. Without it the drawn
 route would stop at the last corner, up to `max_seg` (512u) short of the truth. It is
 skipped only when the run happened to end on a point the gate had already emitted.
+
+From 2.7.2 that closing origin is **validated before use**, and the run-ending event reuses
+the same reading rather than taking its own. A reading is rejected if it is missing, exactly
+`0 0 0`, or further from the last sampled vertex than a player could have travelled (2000u).
+The `handle_disconnect` path is why: it runs from `et_ClientDisconnect`, where the entity may
+already be torn down. When a reading is rejected the closing sample is omitted and the
+run-ending event carries **no `pos`** — the event itself is still emitted. Two guarantees
+follow: `obj_secured` / `obj_dropped` / `obj_carrierkilled.victim_pos` always equal the run's
+final `carrier_pos`, and no coordinate is ever a placeholder.
+
+> **Changed in 2.7.2 — affects reading stored reports.** On 2.7.1 and earlier, `carrier_pos`
+> and `vehicle_pos` are stamped on the engine's frame clock while every other event is
+> stamped with `et.trap_Milliseconds()`. The two run several seconds apart (measured ~10.2s
+> on `karsiah_te2` round 1 of match `075fe912`, ~3.3s for `vehicle_pos` on `supply`), so in
+> those reports telemetry `leveltime` is **not comparable** to any other event's, samples
+> appear after `round_end`, and each run's closing point sorts *before* its own approach —
+> which draws as a straight line across the map. **Read pre-2.7.2 telemetry in array order,
+> not `leveltime` order**; the coordinates themselves are correct and the routes are
+> continuous when read that way. From 2.7.2 both clocks are the timeline clock and either
+> ordering works.
 
 > **Changed in 2.7.1.** Rounds recorded on 2.7.0 carry `carrier_pos` / `vehicle_pos` at a
 > flat 1s cadence, with the emit-time `leveltime` and no closing point. They remain valid
@@ -415,6 +501,12 @@ skipped only when the run happened to end on a point the gate had already emitte
 |-------|-------------|
 | `player` | GUID |
 | `flag` | Flag name (`allies_flag`, `axis_flag`, or config key) |
+| `pos` | The credited player's origin. 2.7.2+ |
+| `flag_pos` | The checkpoint entity's own position. 2.7.2+ |
+
+Credit is proximity-based and given to every player within range of the flag, so one capture
+can produce several events: `pos` says who was there, `flag_pos` says where "there" was and is
+the same on all of them.
 
 **`pickup`** — console-log pickup/use event
 
@@ -744,22 +836,41 @@ interface MessageEvent extends GamelogEventBase {
 type ObjectiveLabel = "obj_planted" | "obj_defused" | "obj_destroyed" | "obj_repaired"
                     | "obj_taken"   | "obj_repickup" | "obj_secured" | "obj_returned";
 
+/** Per-round carry-run id, 2.7.2+. Allocated on each pickup from 1, shared by the
+ *  run's carrier_pos samples and the events that open and close it. Group by this
+ *  rather than by (player, objective) — one player can carry one objective several
+ *  times in a round. Absent before 2.7.2. */
+type CarryRun = number;
+
 interface ObjectiveEvent extends GamelogEventBase {
   group:     "player";
   label:     ObjectiveLabel;
   player:    Guid;
   objective: string;
-  pos?:      Position;  // obj_taken / obj_repickup / obj_secured: run start & end
+  /** Acting player's origin. 2.7.2+ on every label; before that only on
+   *  obj_taken / obj_repickup / obj_secured. Two labels use a different source:
+   *  obj_destroyed is the charge's plant position, or the destroyed entity's own
+   *  origin for announce-only destructions; a WORLD obj_returned is where the
+   *  carry ended. Absent only where no trustworthy source existed — see the
+   *  per-label table in the docs. */
+  pos?:      Position;
+  /** Only on the labels that bound a run. */
+  run?:      CarryRun;
 }
 
 // Killed an enemy objective carrier — killer-credited
 interface ObjCarrierKilledEvent extends GamelogEventBase {
-  group:     "player";
-  label:     "obj_carrierkilled";
-  player:    Guid;    // killer
-  victim:    Guid;    // carrier
-  objective: string;
-  weapon:    number;
+  group:      "player";
+  label:      "obj_carrierkilled";
+  player:     Guid;    // killer
+  victim:     Guid;    // carrier
+  objective:  string;
+  weapon:     number;
+  pos?:       Position;  // killer origin, 2.7.2+
+  /** Carrier origin — where the objective went down. 2.7.2+ */
+  victim_pos?: Position;
+  /** The *victim's* run, which this kill ends. 2.7.2+ */
+  run?:       CarryRun;
 }
 
 interface ObjDroppedEvent extends GamelogEventBase {
@@ -767,7 +878,10 @@ interface ObjDroppedEvent extends GamelogEventBase {
   label:     "obj_dropped";
   player:    Guid;
   objective: string;
+  /** null when the origin reading failed validation (e.g. a torn-down entity on
+   *  the disconnect path). Never a placeholder coordinate. */
   pos:       Position | null;
+  run?:      CarryRun;  // 2.7.2+
 }
 
 interface CarrierPosEvent extends GamelogEventBase {  // COLLECT_VEHICLE_TELEMETRY
@@ -776,6 +890,8 @@ interface CarrierPosEvent extends GamelogEventBase {  // COLLECT_VEHICLE_TELEMET
   player:    Guid;
   objective: string;
   pos:       Position;   // path vertex; spacing is irregular, use leveltime
+  /** 2.7.2+. Group by this to partition a round's samples into carries. */
+  run?:      CarryRun;
 }
 
 // ─── vehicle events (COLLECT_VEHICLE_STATS) ────────────────────────────────
@@ -822,6 +938,11 @@ interface FlagCapturedEvent extends GamelogEventBase {
   label:  "obj_flag_captured";
   player: Guid;
   flag:   string;
+  /** Credited player's origin. Credit is proximity-based and given to everyone in
+   *  range, so one capture can produce several of these events. 2.7.2+ */
+  pos?:      Position;
+  /** The checkpoint entity's own position — identical across those events. 2.7.2+ */
+  flag_pos?: Position;
 }
 
 interface PickupEvent extends GamelogEventBase {
@@ -963,7 +1084,7 @@ The match-ID endpoint is called as `GET {API_URL_MATCHID}/{server_ip}/{server_po
 | `COLLECT_MOVEMENT_STATS` | `true` | Distance travelled and speed in `player_stats` |
 | `COLLECT_STANCE_STATS` | `true` | Stance-time breakdown in `player_stats` |
 | `COLLECT_VEHICLE_STATS` | `true` | Entity-state escort vehicle tracking: per-player escort credit (`player_stats.obj_vehicle.escort`) and `vehicle_*` timeline events in `gamelog`. Active only on maps with an `escort` config section — its entry names (or `script_name` keys) pin the vehicle script_movers; maps without one have no vehicle and are skipped entirely. |
-| `COLLECT_VEHICLE_TELEMETRY` | `true` | Path-vertex position samples for moving vehicles (`vehicle_pos`) and objective carriers (`carrier_pos`), enabling route replay. Sampled per frame, emitted only where the path turns, so volume is independent of `sv_fps` and stays at or below one point per second (~200 events per escort round). |
+| `COLLECT_VEHICLE_TELEMETRY` | `true` | Path position samples for moving vehicles (`vehicle_pos`) and objective carriers (`carrier_pos`), enabling route replay. Sampled per frame; volume is independent of `sv_fps` in both cases. **Vehicles** emit only where the path turns — at or below one point per second (~200 events per escort round). **Carriers** additionally hold a 10 Hz floor while moving (2.7.2+), giving ~32 units between samples so carry distance is measured rather than estimated: expect roughly `10 x carry_seconds` per round (~2100 on the heaviest round measured, versus 423 under pure vertex gating), and 1 Hz while a carrier stands still. |
 | `COLLECT_VEHICLE_DAMAGE` | `true` | Per-player damage tracking for damageable objectives: `vehicle_damage` events + `player_stats.obj_vehicle.damage` / `.repairs` for vehicles, and `obj_damage` events for `ET_CONSTRUCTIBLE` objectives (command posts, breach walls, barriers). Corpse gibs and decorative breakables are filtered out; damage is clamped to remaining health. Trucks are not damageable and never emit these. |
 
 ### [OUTPUT]

--- a/luascripts/stats.lua
+++ b/luascripts/stats.lua
@@ -1,6 +1,6 @@
 --[[
     stats.lua  — root module for ETLegacy game stats collection
-    Version: 2.7.1
+    Version: 2.7.2
 
     All user-facing settings live in the CONFIGURATION block below.
     config.toml is kept only for map-specific patterns and common buildables.
@@ -57,8 +57,8 @@ local AUTO_CONFIG_MAP = {
 }
 
 -- [AUTO-START TIMING]
-local AUTO_START_WAIT_INITIAL   = 420    -- seconds  (First Round, 7min)
-local AUTO_START_WAIT           = 180    -- seconds  (Consecutive Rounds, 3 min)
+local AUTO_START_WAIT_INITIAL   = 300    -- seconds  (First Round, 7min)
+local AUTO_START_WAIT           = 120    -- seconds  (Consecutive Rounds, 3 min)
 
 -- [AUTO-START PHASED MODE]
 -- "simple"  → single window using AUTO_START_WAIT_INITIAL / AUTO_START_WAIT (default).
@@ -76,7 +76,7 @@ local SAVE_STATS_DELAY          = 3000   -- ms after intermission before SaveSta
 
 -- [MODULE]
 local MODNAME                   = "stats"
-local VERSION                   = "2.7.1"
+local VERSION                   = "2.7.2"
 
 -- [ENV OVERRIDES]
 -- Any setting above can be overridden by an environment variable of the same
@@ -461,8 +461,24 @@ end
 
 -- ============================================================ --
 
+-- TWO CLOCKS, do not mix them. They run several seconds apart and the offset drifts.
+--
+--   frame_level_time       -- the level clock the engine passes to this callback. Use it for
+--                             intervals inside one module, and to pair with values the engine
+--                             itself stamps in level time: CS_LEVEL_START_TIME
+--                             (events.calc_reinf_time) and pers.lastSpawnTime
+--                             (movement.track). Those two are correct as-is -- do not
+--                             "fix" them to now_ms or spawn/reinforce detection breaks.
+--   et.trap_Milliseconds() -- the timeline clock. gamelog.record stamps every event with it,
+--                             gamestate.round_end_time uses it, and the pause markers whose
+--                             drift ingest subtracts are measured on it.
+--
+-- Rule: anything that becomes a timestamp, or is compared against one, uses now_ms.
+-- Passing frame_level_time to the telemetry ticks put vehicle_pos/carrier_pos ~6s ahead of
+-- round_end and left the 3s damage/repair attribution windows comparing across the offset.
 function et_RunFrame(frame_level_time)
     level_time = frame_level_time
+    local now_ms = et.trap_Milliseconds()
 
     http.poll_pending(frame_level_time)
 
@@ -501,16 +517,21 @@ function et_RunFrame(frame_level_time)
         _was_paused = false
     end
 
+    -- now_ms, not frame_level_time: these emit timestamped telemetry and compare against
+    -- stamps taken with et.trap_Milliseconds() elsewhere (vehicle.on_damage via events.lua,
+    -- vehicle.on_repair via objectives.lua).
     if COLLECT_VEHICLE_STATS then
-        vehicle.tick(frame_level_time, paused, is_playing)
+        vehicle.tick(now_ms, paused, is_playing)
     end
     -- carrier upkeep: manual-drop (+dropobj) detection + carrier telemetry
     if (COLLECT_OBJ_STATS or COLLECT_GAMELOG) and is_playing and not paused then
-        objectives.tick(frame_level_time)
+        objectives.tick(now_ms)
     end
 
+    -- now_ms so both ends of the round are measured on the timeline clock: round_end_time
+    -- is et.trap_Milliseconds() (gamestate.lua), as is et_InitGame's round_start_time.
     if current_gs == et.GS_PLAYING and gamestate.round_start_time == 0 then
-        gamestate.round_start_time = frame_level_time
+        gamestate.round_start_time = now_ms
         gamestate.round_start_unix = os.time()
     end
 

--- a/luascripts/stats/gamelog.lua
+++ b/luascripts/stats/gamelog.lua
@@ -157,37 +157,53 @@ end
 -- Generic objective event (label is the event type string, e.g. "obj_planted").
 -- pos is optional: obj_taken / obj_repickup carry it so a carrier route has a
 -- true start vertex (and a run has a start coordinate).
-function gamelog.objective(label, guid, obj_name, pos)
+-- run is the carry-run id, on the labels that open or close a run.
+function gamelog.objective(label, guid, obj_name, pos, run)
     gamelog.record(label, "player", {
         player    = guid,
         objective = obj_name,
         pos       = pos,
+        run       = run,
     })
 end
 
--- Flag captured
-function gamelog.obj_flag_captured(guid, flag_name)
+-- Flag captured.
+-- pos is the crediting player's origin; flag_pos is the checkpoint entity's own
+-- position, which is where the flag is regardless of who is standing near it.
+-- Credit goes to everyone within range, so several of these share one flag_pos.
+function gamelog.obj_flag_captured(guid, flag_name, pos, flag_pos)
     gamelog.record("obj_flag_captured", "player", {
-        player = guid,
-        flag   = flag_name,
+        player   = guid,
+        flag     = flag_name,
+        pos      = pos,
+        flag_pos = flag_pos,
     })
 end
 
--- Killed an enemy objective carrier — credited to the killer
-function gamelog.obj_carrier_killed(killer_guid, victim_guid, obj_name, weapon)
+-- Killed an enemy objective carrier — credited to the killer.
+-- pos/victim_pos follow gamelog.kill's killer_pos/victim_pos convention: pos
+-- belongs to `player` (the killer), victim_pos to the carrier who went down.
+-- victim_pos is the interesting one for a replay -- it is where the objective
+-- was dropped, and it closes the carry run named by `run`.
+function gamelog.obj_carrier_killed(killer_guid, victim_guid, obj_name, weapon, run,
+                                    pos, victim_pos)
     gamelog.record("obj_carrierkilled", "player", {
-        player    = killer_guid,
-        victim    = victim_guid,
-        objective = obj_name,
-        weapon    = weapon,
+        player     = killer_guid,
+        victim     = victim_guid,
+        objective  = obj_name,
+        weapon     = weapon,
+        run        = run,
+        pos        = pos,
+        victim_pos = victim_pos,
     })
 end
 
-function gamelog.obj_dropped(guid, obj_name, pos)
+function gamelog.obj_dropped(guid, obj_name, pos, run)
     gamelog.record("obj_dropped", "player", {
         player    = guid,
         objective = obj_name,
         pos       = pos,
+        run       = run,
     })
 end
 
@@ -215,11 +231,16 @@ end
 -- Objective-carrier position telemetry sample.
 -- leveltime is the moment the position was sampled, which for a corner vertex
 -- is a few frames before the event is emitted.
-function gamelog.carrier_pos(guid, obj_name, pos, leveltime)
+-- run identifies the carry this sample belongs to, so a consumer can partition
+-- the series with a group-by instead of replaying the surrounding events. The
+-- same player can carry the same objective several times in one round, which is
+-- what makes the id load-bearing rather than a convenience.
+function gamelog.carrier_pos(guid, obj_name, pos, leveltime, run)
     gamelog.record("carrier_pos", "player", {
         player    = guid,
         objective = obj_name,
         pos       = pos,
+        run       = run,
     }, leveltime)
 end
 

--- a/luascripts/stats/objectives.lua
+++ b/luascripts/stats/objectives.lua
@@ -60,33 +60,80 @@ local DESTROY_DEDUP_MS      = 1500
 local _collect_telemetry    = false
 local _carrier_gates        = {}   -- [clientNum] = pathgate instance
 
+-- Carry-run identity. Every pickup opens a numbered run, and the number is
+-- stamped on the run's carrier_pos samples and on the events that open and close
+-- it. Without it a consumer has to rebuild run boundaries by interleaving
+-- events, and the ambiguity is real rather than theoretical: one karsiah round
+-- has a single player take the same documents four separate times, so
+-- (player, objective) does not identify a run. Ids are per round, allocated in
+-- pickup order from 1, and shared across objectives.
+local _run_seq              = 0
+local _carrier_run_id       = {}   -- [clientNum] = run id
+
 -- Active map config
 local _map_config           = nil
 local _common_buildables    = nil
 
 
+-- Furthest a run's closing position may sit from the last sampled vertex before
+-- we stop believing it. This is the ingest side's teleport threshold, and with
+-- the carrier sample floor the last vertex is at most ~32 units old, so the
+-- bound is slack by two orders of magnitude -- it only ever catches a reading
+-- that is wrong, never one that is merely stale.
+local MAX_CLOSING_JUMP = 2000
+
+-- A run's exit path reads the carrier's origin one last time, and that read is
+-- not always trustworthy. handle_disconnect runs from et_ClientDisconnect,
+-- where the entity may already be torn down and read as the world origin, and
+-- any stale or zeroed value would be drawn as a line from the route to the
+-- corner of the map. Reject the implausible rather than emit it: a missing
+-- reading, an exact 0 0 0, or a jump no player could have made since the last
+-- known-good vertex.
+--
+-- Note pers.connected is useless as a guard here -- the engine does not clear
+-- it until the end of ClientDisconnect, so it still reads CON_CONNECTED on the
+-- one path that needs checking.
+local function plausible_origin(pos, last)
+    if not pos then return nil end
+    if pos[1] == 0 and pos[2] == 0 and pos[3] == 0 then return nil end
+    if last and utils.distance3d_units(last, pos) > MAX_CLOSING_JUMP then return nil end
+    return pos
+end
+
+
+-- Closes out a carry: emits the run's final carrier_pos and returns the
+-- validated position, so the caller's own obj_secured / obj_dropped describes
+-- the same instant instead of issuing a second, separately-trusted read.
+-- Returns nil when no position could be trusted, in which case the caller
+-- should emit no pos at all.
+--
 -- gamelog_module mirrors handle_carrier_death's override: the final point must
 -- land in the same buffer as the event that ends the run, not a different one.
 local function end_carrier_run(clientNum, gamelog_module)
     local gate = _carrier_gates[clientNum]
     _carrier_gates[clientNum] = nil
 
+    -- Validate before any of the emit-side early returns: the position is the
+    -- return value and callers need it whether or not telemetry is collected.
+    local pos = plausible_origin(et.gentity_get(clientNum, "r.currentOrigin"),
+                                gate and gate:last_emitted())
+    if not pos then return nil end
+
     local gl = gamelog_module or gamelog_ref
-    if not gate or not _collect_telemetry or not _collect_gamelog or not gl then return end
+    if not gate or not _collect_telemetry or not _collect_gamelog or not gl then return pos end
 
     local obj_name = objective_carriers.players[clientNum]
     local entry    = players_ref.guids[clientNum]
-    if not obj_name or not entry or not entry.guid or entry.guid == "WORLD" then return end
-
-    local pos = et.gentity_get(clientNum, "r.currentOrigin")
-    if not pos then return end
+    if not obj_name or not entry or not entry.guid or entry.guid == "WORLD" then return pos end
 
     -- Nothing to close out when the run already ended on a vertex (a parked
     -- carrier whose heartbeat just fired at this exact spot).
     local last = gate:last_emitted()
-    if last and utils.distance3d_units(last, pos) < 1 then return end
+    if last and utils.distance3d_units(last, pos) < 1 then return pos end
 
-    gl.carrier_pos(entry.guid, obj_name, utils.fmt_pos(pos), et.trap_Milliseconds())
+    gl.carrier_pos(entry.guid, obj_name, utils.fmt_pos(pos), et.trap_Milliseconds(),
+        _carrier_run_id[clientNum])
+    return pos
 end
 
 
@@ -206,6 +253,13 @@ local function update_objective_state(obj_name, action, guid, normalized_text)
     objective_states[obj_name].timestamp   = ts
     objective_states[obj_name].last_action = action
 
+    -- Rebuilding clears any remembered charge position: the next destruction of
+    -- this objective is a new charge, and must not inherit the old one's
+    -- coordinate. Handled here rather than at the four construct call sites.
+    if action == "constructed" then
+        objective_states[obj_name].plant_pos = nil
+    end
+
     if normalized_text then
         objective_states[obj_name].last_announce = normalized_text
     end
@@ -253,6 +307,27 @@ local function find_nearest_players(coordinates, team)
 end
 
 
+-- Credit a flag capture to every player the announce implicates. Each gets their
+-- own origin as pos, and they share the checkpoint's position as flag_pos --
+-- credit is proximity-based, so pos says who was there and flag_pos says where
+-- "there" was. Shared by the allies, axis and named-flag branches, which differ
+-- only in which team is searched.
+local function credit_flag_capture(flag_name, flag_coordinates, team)
+    local flag_pos = utils.fmt_pos(parse_coords(flag_coordinates))
+
+    for _, cnum in ipairs(find_nearest_players(flag_coordinates, team)) do
+        local guid = players_ref.guids[cnum] and players_ref.guids[cnum].guid
+        if guid then
+            record_obj_stat(guid, "obj_flagcaptured", flag_name)
+            if _collect_gamelog and gamelog_ref then
+                gamelog_ref.obj_flag_captured(guid, flag_name,
+                    utils.fmt_pos(et.gentity_get(cnum, "r.currentOrigin")), flag_pos)
+            end
+        end
+    end
+end
+
+
 local function get_flag_coordinates()
     local flags = {}
     for i = 64, 1021 do
@@ -277,14 +352,29 @@ local function get_flag_coordinates()
 end
 
 
-local function emit_destroyed(guid, obj_name, normalized_text)
+-- entity_pos is supplied by the announce-only path, which knows the entity that
+-- was destroyed; the Objective_Destroyed path has no entity but does have a
+-- charge, so it falls back to the plant position.
+local function emit_destroyed(guid, obj_name, normalized_text, entity_pos)
     if guid then
         record_obj_stat(guid, "obj_destroyed", obj_name)
         if _collect_gamelog and gamelog_ref then
-            gamelog_ref.objective("obj_destroyed", guid, obj_name)
+            -- Never the attributed player's live origin: a dynamite destruction
+            -- fires ~30s after the plant (karsiah r1: planted 3119603, destroyed
+            -- 3149585) and by then the planter is usually dead or respawned, so
+            -- their origin would put the marker on a spawn point. The charge's
+            -- own position, remembered at plant time, is where it went off.
+            local state = objective_states[obj_name]
+            gamelog_ref.objective("obj_destroyed", guid, obj_name,
+                entity_pos or (state and state.plant_pos))
         end
     end
     update_objective_state(obj_name, "destroyed", nil, normalized_text)
+
+    -- The charge is spent either way; do not let a later destruction of the same
+    -- objective replay this one's coordinate.
+    local state = objective_states[obj_name]
+    if state then state.plant_pos = nil end
 end
 
 
@@ -293,17 +383,32 @@ end
 -- announce fires in the same frame as the killing blow.
 local function handle_buildable_destruction(obj_name, normalized_text)
     local current_time = et.trap_Milliseconds()
-    local guid
+    local guid, entnum
     for _, dmg in ipairs(recent_entity_damage) do
         if (current_time - dmg.timestamp) <= ENTITY_DAMAGE_WINDOW_MS then
             local entry = players_ref.guids[dmg.attacker]
             if entry and entry.guid and entry.guid ~= "WORLD" then
-                guid = entry.guid
+                guid   = entry.guid
+                entnum = dmg.entnum
                 break
             end
         end
     end
-    emit_destroyed(guid, obj_name, normalized_text)
+
+    -- These destructions have no charge to replay a position from, but the thing
+    -- destroyed is itself an entity and we already know which one: events.lua
+    -- filters et_Damage down to ET_CONSTRUCTIBLE before buffering it, so
+    -- dmg.entnum *is* the objective. Read its origin directly.
+    --
+    -- Deliberately not the attacker's position. It is a fair proxy for a satchel,
+    -- which has to be placed on the target, but not for the panzerfaust or tank
+    -- shell that can take a command post from across the map.
+    local pos
+    if entnum then
+        pos = utils.fmt_pos(plausible_origin(et.gentity_get(entnum, "r.currentOrigin")))
+    end
+
+    emit_destroyed(guid, obj_name, normalized_text, pos)
 end
 
 
@@ -361,6 +466,29 @@ local function handle_dynamite_event(text, event_type, action_name)
     local guid            = entry.guid
     local normalized_text = utils.normalize(event_text:match("^%s*(.-)%s*$") or event_text)
 
+    -- Both match branches below emit identically; only the pattern source differs.
+    local function emit(obj_name)
+        local stat_key = "obj_" .. action_name
+        record_obj_stat(guid, stat_key, obj_name)
+        update_objective_state(obj_name, action_name, entry)
+
+        -- The planter/defuser is standing at the dynamite, so their origin is
+        -- the objective's location. Remember it on a plant: obj_destroyed fires
+        -- ~30s later, by which time the planter is usually dead or respawned
+        -- elsewhere and their live origin says nothing about where the charge
+        -- went off. A defuse removes the charge, so the stored position goes
+        -- with it.
+        local pos = et.gentity_get(id, "r.currentOrigin")
+        local state = objective_states[obj_name]
+        if state then
+            state.plant_pos = (action_name == "planted") and utils.fmt_pos(pos) or nil
+        end
+
+        if _collect_gamelog and gamelog_ref then
+            gamelog_ref.objective(stat_key, guid, obj_name, utils.fmt_pos(pos))
+        end
+    end
+
     if _common_buildables then
         for obj_name, common_cfg in pairs(_common_buildables) do
             if _map_config.buildables and _map_config.buildables[obj_name] then
@@ -373,12 +501,7 @@ local function handle_dynamite_event(text, event_type, action_name)
                         end
                     end
                     if matched then
-                        local stat_key = "obj_" .. action_name
-                        record_obj_stat(guid, stat_key, obj_name)
-                        update_objective_state(obj_name, action_name, entry)
-                        if _collect_gamelog and gamelog_ref then
-                            gamelog_ref.objective(stat_key, guid, obj_name)
-                        end
+                        emit(obj_name)
                         return
                     end
                 end
@@ -390,12 +513,7 @@ local function handle_dynamite_event(text, event_type, action_name)
         for obj_name, obj_cfg in pairs(_map_config.buildables) do
             if type(obj_cfg) ~= "boolean" and obj_cfg.plant_pattern and obj_cfg.plant_pattern ~= "" then
                 if string.find(normalized_text, utils.normalize(obj_cfg.plant_pattern)) then
-                    local stat_key = "obj_" .. action_name
-                    record_obj_stat(guid, stat_key, obj_name)
-                    update_objective_state(obj_name, action_name, entry)
-                    if _collect_gamelog and gamelog_ref then
-                        gamelog_ref.objective(stat_key, guid, obj_name)
-                    end
+                    emit(obj_name)
                     break
                 end
             end
@@ -643,32 +761,14 @@ function objectives.handle_print(text)
             local allies_cfg = _map_config.flags.allies_flag
             if allies_cfg and allies_cfg.flag_pattern and allies_cfg.flag_coordinates
             and string.find(normalized, utils.normalize(allies_cfg.flag_pattern)) then
-                local nearest = find_nearest_players(allies_cfg.flag_coordinates, et.TEAM_ALLIES)
-                for _, cnum in ipairs(nearest) do
-                    local guid = players_ref.guids[cnum] and players_ref.guids[cnum].guid
-                    if guid then
-                        record_obj_stat(guid, "obj_flagcaptured", "allies_flag")
-                        if _collect_gamelog and gamelog_ref then
-                            gamelog_ref.obj_flag_captured(guid, "allies_flag")
-                        end
-                    end
-                end
+                credit_flag_capture("allies_flag", allies_cfg.flag_coordinates, et.TEAM_ALLIES)
             end
 
             -- Axis flag
             local axis_cfg = _map_config.flags.axis_flag
             if axis_cfg and axis_cfg.flag_pattern and axis_cfg.flag_coordinates
             and string.find(normalized, utils.normalize(axis_cfg.flag_pattern)) then
-                local nearest = find_nearest_players(axis_cfg.flag_coordinates, et.TEAM_AXIS)
-                for _, cnum in ipairs(nearest) do
-                    local guid = players_ref.guids[cnum] and players_ref.guids[cnum].guid
-                    if guid then
-                        record_obj_stat(guid, "obj_flagcaptured", "axis_flag")
-                        if _collect_gamelog and gamelog_ref then
-                            gamelog_ref.obj_flag_captured(guid, "axis_flag")
-                        end
-                    end
-                end
+                credit_flag_capture("axis_flag", axis_cfg.flag_coordinates, et.TEAM_AXIS)
             end
 
             -- Generic named flags in config
@@ -678,16 +778,7 @@ function objectives.handle_print(text)
                 and string.find(normalized, utils.normalize(flag_cfg.flag_pattern)) then
                     -- Closest player from either team
                     for _, team in ipairs({ et.TEAM_ALLIES, et.TEAM_AXIS }) do
-                        local nearest = find_nearest_players(flag_cfg.flag_coordinates, team)
-                        for _, cnum in ipairs(nearest) do
-                            local guid = players_ref.guids[cnum] and players_ref.guids[cnum].guid
-                            if guid then
-                                record_obj_stat(guid, "obj_flagcaptured", flag_name)
-                                if _collect_gamelog and gamelog_ref then
-                                    gamelog_ref.obj_flag_captured(guid, flag_name)
-                                end
-                            end
-                        end
+                        credit_flag_capture(flag_name, flag_cfg.flag_coordinates, team)
                     end
                 end
             end
@@ -747,11 +838,18 @@ function objectives.handle_print(text)
                     if entry and entry.guid and entry.guid ~= "WORLD" then
                         local event = state.dropped and "obj_repickup" or "obj_taken"
                         record_obj_stat(entry.guid, event, obj.name)
+
+                        -- A pickup is the only thing that opens a run, so it is
+                        -- the only place an id is allocated.
+                        _run_seq = _run_seq + 1
+                        _carrier_run_id[touch_id] = _run_seq
+
                         if _collect_gamelog and gamelog_ref then
                             -- pos anchors the route: this is the exact start of
                             -- the run, a frame ahead of the first carrier_pos.
                             local pos = et.gentity_get(touch_id, "r.currentOrigin")
-                            gamelog_ref.objective(event, entry.guid, obj.name, utils.fmt_pos(pos))
+                            gamelog_ref.objective(event, entry.guid, obj.name,
+                                utils.fmt_pos(pos), _run_seq)
                         end
 
                         -- Fresh gate per run, so a re-pickup never continues the
@@ -760,6 +858,11 @@ function objectives.handle_print(text)
 
                         objective_carriers.players[touch_id] = obj.name
                         state.carrier_id = touch_id
+                        -- The previous run is no longer the one a return would
+                        -- terminate; this one is, once it ends. Its resting place
+                        -- goes with it -- the objective is off the ground now.
+                        state.last_run   = nil
+                        state.last_pos   = nil
                     end
 
                     state.dropped     = false
@@ -773,14 +876,38 @@ function objectives.handle_print(text)
                     local entry = touch_id and players_ref.guids[touch_id]
                     local returner_guid = entry and entry.guid or "WORLD"
 
+                    -- A return names the run it terminated, which is almost never
+                    -- a live one: an objective is returned while it lies on the
+                    -- ground, so its run already closed at the obj_dropped and
+                    -- state.carrier_id is nil by now. state.last_run is that run,
+                    -- and it is the useful link -- it says this carry ended in a
+                    -- reset rather than in someone picking the objective back up.
+                    -- The carrier_id branch is defensive, for a return that
+                    -- somehow lands while a carry is still in flight.
                     local state = objective_states[obj.name]
+                    local ended_run = state and state.last_run
                     if state and state.carrier_id then
+                        ended_run = _carrier_run_id[state.carrier_id]
+                        -- Note the two positions differ: end_carrier_run's is
+                        -- where the carry stopped, pos below is where the
+                        -- returner was standing.
                         end_carrier_run(state.carrier_id)
                     end
 
                     record_obj_stat(returner_guid, "obj_returned", obj.name)
                     if _collect_gamelog and gamelog_ref then
-                        gamelog_ref.objective("obj_returned", returner_guid, obj.name)
+                        -- The returner's origin is where the objective was lying,
+                        -- since they had to reach it to return it. A WORLD return
+                        -- has no actor -- the objective timed out back to its
+                        -- stand after being dropped and left -- so fall back to
+                        -- where the carry ended, which is where it sat until the
+                        -- timer ran out. Same place, one of them observed via a
+                        -- player and the other remembered.
+                        local pos = touch_id
+                            and utils.fmt_pos(et.gentity_get(touch_id, "r.currentOrigin"))
+                            or (state and state.last_pos)
+                        gamelog_ref.objective("obj_returned", returner_guid, obj.name,
+                            pos, ended_run)
                     end
 
                     if state then
@@ -845,7 +972,10 @@ function objectives.handle_print(text)
 
                 record_obj_stat(guid, "obj_repaired", objective_name)
                 if _collect_gamelog and gamelog_ref then
-                    gamelog_ref.objective("obj_repaired", guid, objective_name)
+                    -- The engineer is standing at what they are repairing.
+                    local pos = et.gentity_get(id, "r.currentOrigin")
+                    gamelog_ref.objective("obj_repaired", guid, objective_name,
+                        utils.fmt_pos(pos))
                 end
             end
         end
@@ -876,17 +1006,19 @@ function objectives.handle_print(text)
                 and string.find(first_sentence, utils.normalize(obj.secured_pattern)) then
                     for carrier_id, carried_obj in pairs(objective_carriers.players) do
                         if carried_obj == obj.name then
-                            end_carrier_run(carrier_id)
+                            -- pos closes the run: paired with obj_taken's start
+                            -- coordinate it bounds the route exactly. Taken from
+                            -- end_carrier_run so it is the same validated
+                            -- reading as the run's final carrier_pos.
+                            local run = _carrier_run_id[carrier_id]
+                            local pos = end_carrier_run(carrier_id)
 
                             local entry = players_ref.guids[carrier_id]
                             if entry then
                                 record_obj_stat(entry.guid, "obj_secured", obj.name)
                                 if _collect_gamelog and gamelog_ref then
-                                    -- pos closes the run: paired with obj_taken's
-                                    -- start coordinate it bounds the route exactly.
-                                    local pos = et.gentity_get(carrier_id, "r.currentOrigin")
                                     gamelog_ref.objective("obj_secured", entry.guid, obj.name,
-                                        utils.fmt_pos(pos))
+                                        utils.fmt_pos(pos), run)
                                 end
                             end
 
@@ -898,6 +1030,7 @@ function objectives.handle_print(text)
                             if secured_state then
                                 secured_state.carrier_id = nil
                                 secured_state.dropped    = false
+                                secured_state.last_run   = run
                             end
                             break
                         end
@@ -921,7 +1054,8 @@ function objectives.handle_carrier_death(target, attacker, mod, gamelog_module)
 
             local gl = gamelog_module or gamelog_ref
 
-            end_carrier_run(target, gl)
+            local run = _carrier_run_id[target]
+            local pos = end_carrier_run(target, gl)
 
             if killer_entry and killer_entry.guid and killer_entry.guid ~= "WORLD"
             and attacker ~= target
@@ -932,20 +1066,26 @@ function objectives.handle_carrier_death(target, attacker, mod, gamelog_module)
                     objective = obj_name,
                 })
                 if _collect_gamelog and gl then
-                    gl.obj_carrier_killed(killer_entry.guid, victim_guid, obj_name, mod)
+                    -- victim_pos is `pos` from end_carrier_run: where the carry
+                    -- stopped, and the same reading the closing carrier_pos and
+                    -- obj_dropped use. The killer's own origin is read fresh.
+                    gl.obj_carrier_killed(killer_entry.guid, victim_guid, obj_name, mod, run,
+                        utils.fmt_pos(et.gentity_get(attacker, "r.currentOrigin")),
+                        utils.fmt_pos(pos))
                 end
             end
 
             record_obj_stat(victim_guid, "obj_dropped", obj_name)
             if _collect_gamelog and gl then
-                local pos = et.gentity_get(target, "r.currentOrigin")
-                gl.obj_dropped(victim_guid, obj_name, utils.fmt_pos(pos))
+                gl.obj_dropped(victim_guid, obj_name, utils.fmt_pos(pos), run)
             end
 
             objective_carriers.players[target] = nil
             state.carrier_id  = nil
             state.dropped     = true
             state.last_action = "dropped"
+            state.last_run    = run
+            state.last_pos    = utils.fmt_pos(pos)
             state.timestamp   = et.trap_Milliseconds()
         end
     end
@@ -959,18 +1099,24 @@ function objectives.handle_disconnect(clientNum)
             local entry = players_ref.guids[clientNum]
             local guid  = entry and entry.guid or "WORLD"
 
-            end_carrier_run(clientNum)
+            -- The disconnect path is exactly why end_carrier_run validates: the
+            -- entity may already be torn down here, and a zeroed origin would
+            -- put both the closing sample and this obj_dropped at the world
+            -- origin. A nil pos is the correct outcome, not a fabricated one.
+            local run = _carrier_run_id[clientNum]
+            local pos = end_carrier_run(clientNum)
 
             record_obj_stat(guid, "obj_dropped", obj_name)
             if _collect_gamelog and gamelog_ref then
-                local pos = et.gentity_get(clientNum, "r.currentOrigin")
-                gamelog_ref.obj_dropped(guid, obj_name, utils.fmt_pos(pos))
+                gamelog_ref.obj_dropped(guid, obj_name, utils.fmt_pos(pos), run)
             end
 
             objective_carriers.players[clientNum] = nil
             state.carrier_id  = nil
             state.dropped     = true
             state.last_action = "dropped"
+            state.last_run    = run
+            state.last_pos    = utils.fmt_pos(pos)
             state.timestamp   = et.trap_Milliseconds()
         end
     end
@@ -1007,12 +1153,12 @@ local function check_manual_drops()
                 local entry = players_ref.guids[clientNum]
                 local guid  = entry and entry.guid or "WORLD"
 
-                end_carrier_run(clientNum)
+                local run = _carrier_run_id[clientNum]
+                local pos = end_carrier_run(clientNum)
 
                 record_obj_stat(guid, "obj_dropped", obj_name)
                 if _collect_gamelog and gamelog_ref then
-                    local pos = et.gentity_get(clientNum, "r.currentOrigin")
-                    gamelog_ref.obj_dropped(guid, obj_name, utils.fmt_pos(pos))
+                    gamelog_ref.obj_dropped(guid, obj_name, utils.fmt_pos(pos), run)
                 end
 
                 objective_carriers.players[clientNum] = nil
@@ -1021,6 +1167,8 @@ local function check_manual_drops()
                     state.carrier_id  = nil
                     state.dropped     = true
                     state.last_action = "dropped"
+                    state.last_run    = run
+                    state.last_pos    = utils.fmt_pos(pos)
                     state.timestamp   = et.trap_Milliseconds()
                 end
             end
@@ -1032,6 +1180,29 @@ end
 -- Per-frame carrier upkeep: manual-drop detection (always) and carrier
 -- position telemetry (collect_vehicle_telemetry, vertex-gated).
 function objectives.tick(now)
+    -- Reap run state for players who no longer carry anything (killed, secured,
+    -- dropped, returned, disconnected) so nothing leaks across runs.
+    --
+    -- Reaped here rather than in end_carrier_run because that function runs
+    -- *before* the event which ends the run in all five exit paths -- clearing
+    -- the id there would strip it off the very event that needs it. Those events
+    -- all fire from handle_print / handle_carrier_death / handle_disconnect, so
+    -- by the time any tick runs they have already read what they needed.
+    --
+    -- Ahead of the no-carriers early return, or the round's final carry would
+    -- never be reaped, and ahead of the telemetry gate, or run ids would leak
+    -- whenever telemetry is switched off.
+    for clientNum in pairs(_carrier_gates) do
+        if objective_carriers.players[clientNum] == nil then
+            _carrier_gates[clientNum] = nil
+        end
+    end
+    for clientNum in pairs(_carrier_run_id) do
+        if objective_carriers.players[clientNum] == nil then
+            _carrier_run_id[clientNum] = nil
+        end
+    end
+
     if next(objective_carriers.players) == nil then return end
 
     check_manual_drops()
@@ -1053,17 +1224,10 @@ function objectives.tick(now)
                 -- and timestamp have to describe the same instant.
                 local vertex, vertex_ms = gate:sample(pos, now)
                 if vertex then
-                    gamelog_ref.carrier_pos(entry.guid, obj_name, utils.fmt_pos(vertex), vertex_ms)
+                    gamelog_ref.carrier_pos(entry.guid, obj_name, utils.fmt_pos(vertex),
+                        vertex_ms, _carrier_run_id[clientNum])
                 end
             end
-        end
-    end
-
-    -- Drop gates for players who no longer carry anything (killed, secured,
-    -- dropped, disconnected) so state cannot leak across runs.
-    for clientNum in pairs(_carrier_gates) do
-        if objective_carriers.players[clientNum] == nil then
-            _carrier_gates[clientNum] = nil
         end
     end
 end
@@ -1098,6 +1262,10 @@ function objectives.reset()
     pending_flag_touch   = nil
     recent_entity_damage = {}
     _carrier_gates       = {}
+    _carrier_run_id      = {}
+    -- Run ids restart at 1 each round: they are only ever meaningful within the
+    -- round they were emitted in, which is the scope a gamelog covers.
+    _run_seq             = 0
     _map_config          = nil
     _common_buildables   = nil
 end

--- a/luascripts/stats/util/pathgate.lua
+++ b/luascripts/stats/util/pathgate.lua
@@ -9,6 +9,11 @@
     ladder/fall changes only z, and a stationary entity produces no geometry
     at all (keepalive keeps the ingest side's segment anchors fresh).
 
+    Corner vertices alone describe a route's shape but chord across it, which
+    under-measures a path that weaves inside the corridor. Profiles that need
+    the distance to be right as well as the shape set move_gap_ms, a spacing
+    floor applied while the entity is actually covering ground.
+
     Usage:
         local gate = pathgate.new(pathgate.CARRIER)
         local vertex, vertex_ms = gate:sample(origin, level_time)  -- every frame
@@ -37,6 +42,14 @@ local pathgate = {}
 --               wherever the timer happened to fire instead of on the corner
 --   max_gap_ms  absolute cap on the interval between points, so even a prone
 --               crawl stays well inside the ingest side's segment gap limit
+--   move_gap_ms sample floor while actually covering ground: once the entity is
+--               min_dir_seg from the anchor, no more than this long may pass
+--               without a point. 0 disables it, leaving pure vertex gating.
+--               Gated on distance rather than on the per-sample `moving` flag
+--               because that flag is frame-rate dependent -- at sv_fps 125 a
+--               sprint covers 2.56u per sample, barely over still_epsilon --
+--               whereas distance from the anchor is not. A parked entity never
+--               clears min_dir_seg and so still falls through to keepalive_ms
 --   still_epsilon  per-sample displacement below which the entity counts as
 --               stopped; coming to a stop pins a vertex at the stopping point
 --   min_gap_ms  floor between points for the stop rule, so stutter-stepping
@@ -55,11 +68,25 @@ local DEFAULTS = {
     dev_epsilon   = 8,
     still_epsilon = 2,
     min_gap_ms    = 250,
+    move_gap_ms   = 0,
 }
 
 -- Objective carriers move at player speed (g_speed 320, more when sprinting
 -- or boosted) and take tight corners.
-pathgate.CARRIER = {}
+--
+-- move_gap_ms gives carriers a 10 Hz floor while they are covering ground. The
+-- corner gates alone draw the route's shape but chord across it between
+-- vertices, so a strafe-jumped or circle-strafed approach measures shorter than
+-- it was; at 320 u/s a 100 ms floor puts samples 32 units apart, inside tol_xy,
+-- and the polyline becomes the path rather than an approximation of it.
+-- Deliberately time-based and not per-frame: sample volume must not depend on
+-- sv_fps, or the same carry produces 2.5x the events on a 125 fps server as on
+-- a 50 fps one with nothing downstream able to tell the two apart. A carrier
+-- standing on the spot never clears min_dir_seg, so it still beats at
+-- keepalive_ms rather than 10 Hz.
+pathgate.CARRIER = {
+    move_gap_ms = 100,
+}
 
 -- Escort vehicles are slow and follow fixed spline paths, so a wider corridor
 -- costs nothing in fidelity.
@@ -204,6 +231,9 @@ function Gate:sample(pos, now)
             vertex, vertex_ms = p, now  -- came to a stop: pin where
         elseif not self.moving and elapsed >= self.keepalive_ms then
             vertex, vertex_ms = p, now  -- parked: heartbeat
+        elseif self.move_gap_ms > 0 and travelled >= self.min_dir_seg
+           and elapsed >= self.move_gap_ms then
+            vertex, vertex_ms = p, now  -- covering ground: hold the sample floor
         elseif elapsed >= self.max_gap_ms then
             vertex, vertex_ms = p, now  -- crawling: bound the gap anyway
         end


### PR DESCRIPTION
…s.tick, and gamestate.round_start_time now take et.trap_Milliseconds()

* Carry routes now trace the real path. Carriers sample at 10 Hz while moving (~32 units apart) instead of only at corners
* Added run to carry telemetry. Per-round carry id on carrier_pos and the events that bound it — group by it instead of reconstructing runs from event order.
* Added pos to every objective event — plants, defuses, destructions, repairs, flag captures, carrier kills. obj_destroyed uses the position the charge was planted at